### PR TITLE
Change paths to also cover legacy

### DIFF
--- a/Context/BrowserSubContext/Authentication.php
+++ b/Context/BrowserSubContext/Authentication.php
@@ -40,7 +40,7 @@ class Authentication extends Base implements AuthenticationSentences
     public function iAmLoggedInAsWithPassword( $user, $password )
     {
         return array(
-            new Step\Given( 'I am on "/login"' ),
+            new Step\Given( 'I am on "login" page' ),
             new Step\When( 'I fill in "Username" with "' . $user . '"' ),
             new Step\When( 'I fill in "Password" with "' . $password . '"' ),
             new Step\When( 'I press "Login"' ),
@@ -55,7 +55,7 @@ class Authentication extends Base implements AuthenticationSentences
     public function iAmNotLoggedIn()
     {
         return array(
-            new Step\Given( 'I am on "/logout"' ),
+            new Step\Given( 'I am on "logout" page' ),
             new Step\Then( 'I should be on "/"' ),
         );
     }


### PR DESCRIPTION
The generic login was made to use `/login` and `/logout` URLs but the legacy (admin2) uses `/user/<action>`

Since the [BrowserContext#L74](https://github.com/ezsystems/BehatBundle/blob/master/Context/BrowserContext.php#L74) has basic/default URLs defined, and we can also defined the legacy ones, changed the generic authentication to work also on admin2 interface 
