### PR TITLE
Add Guzzle4 to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "ezsystems/ezpublish-kernel": "*"
+        "ezsystems/ezpublish-kernel": "*",
+        "guzzlehttp/guzzle": "~4.0"
     },
     "autoload": {
         "psr-0": {"EzSystems\\BehatBundle": ""}


### PR DESCRIPTION
Adding Guzzle 4 to the `composer.json` requirements

This will make ezsystems/ezpublish-kernel/pull/968 possible
