### PR TITLE
Fix typo in browser context common action "I go to the homepage"

### DIFF
--- a/Context/Browser/SubContext/CommonActions.php
+++ b/Context/Browser/SubContext/CommonActions.php
@@ -41,7 +41,7 @@ trait CommonActions
     /**
      * @Given I am on/at the homepage
      * @Given I am on/at (the) :page page
-     * @When I go to the the homepage
+     * @When I go to the homepage
      * @When  I go to (the) :page page
      */
     public function iAmOnPage( $page = 'home' )


### PR DESCRIPTION
This fixes a typo affecting the "When I go to the homepage" sentence.

ref: https://travis-ci.org/ezsystems/DemoBundle/jobs/37487041
