### PR TITLE
Fix EZP-23572: create user and assign role for "I am logged as :role"

### DIFF
--- a/Context/Browser/SubContext/Authentication.php
+++ b/Context/Browser/SubContext/Authentication.php
@@ -20,8 +20,15 @@ trait Authentication
      */
     public function iAmLoggedInAsAn( $role )
     {
-        $credentials = $this->getCredentialsFor( 'administrator' );
-        $this->iAmLoggedInAsWithPassword( $credentials['login'], $credentials['password'] );
+        if ( $role == 'Anonymous' )
+        {
+            $this->iAmNotLoggedIn();
+        }
+        else
+        {
+            $credentials = $this->getCredentialsFor( $role );
+            $this->iAmLoggedInAsWithPassword( $credentials['login'], $credentials['password'] );
+        }
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23572

For the `"@Given I am logged (in) as a(n) :role"` sentence, the `'admin'` user credentials were being used.

This PR modifies/fixes this by creating a new temporary user, and assigning it the needed role.
Requires #16 (User object management/sentences)

After the scenario, user is automatically removed.
