### PR TITLE
EZP-24474: EzContext in BehatBundle should extend MinkContext

### DIFF
--- a/Context/EzContext.php
+++ b/Context/EzContext.php
@@ -9,6 +9,7 @@
 
 namespace EzSystems\BehatBundle\Context;
 
+use Behat\MinkExtension\Context\MinkContext;
 use EzSystems\BehatBundle\Helper;
 use EzSystems\BehatBundle\Context\Object;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
@@ -18,7 +19,7 @@ use Behat\Symfony2Extension\Context\KernelAwareContext;
 /**
  * EzContext has all the needed methods and helpers that are globaly used in contexts
  */
-class EzContext implements KernelAwareContext
+class EzContext extends MinkContext implements KernelAwareContext
 {
     use Object\ContentTypeGroup;
     use Object\UserGroup;


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-24474

I was trying to add a bdd test for a feature i'm adding to our DemoBundle. The feature will try to check if being logged, feedback forms will be prefilled with the data from the user. 
So, my feature looks more or less like
```
    Scenario: As a regular member, I can see my data in the feedback form
        Given I am logged in as "admin" with password "publish"
        Given I am on the "feedback_form" page
         Then the "First Name" field should contain "Administrator"
```
Mink extension has the possibility to check that. It does with this 
https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/Context/MinkContext.php#L364
But even we have that class loaded we aren't taking advantage of this because our EzContexts is not extending it...

I suggest to extend from eZContext to take advantage of all the methods MinkContexts has. But dunno if actually there is a good reason for not extending.

ping @andrerom @miguelcleverti @joaoinacio @bdunogier @lolautruche 
