### PR TITLE
Made EzContext use default SA from settings

### DIFF
--- a/Context/EzContext.php
+++ b/Context/EzContext.php
@@ -26,8 +26,6 @@ class EzContext implements KernelAwareContext
     use Object\FieldType;
     use Object\BasicContent;
 
-    const DEFAULT_SITEACCESS_NAME = 'behat_site';
-
     /**
      * @var \Symfony\Component\HttpKernel\KernelInterface
      */
@@ -90,13 +88,10 @@ class EzContext implements KernelAwareContext
      */
     protected function generateSiteAccess()
     {
-        $siteAccessName = getenv( 'EZPUBLISH_SITEACCESS' );
-        if ( !$siteAccessName )
-        {
-            $siteAccessName = static::DEFAULT_SITEACCESS_NAME;
-        }
-
-        return new SiteAccess( $siteAccessName, 'cli' );
+        return new SiteAccess(
+            getenv( 'EZPUBLISH_SITEACCESS' ) ?: $this->getKernel()->getContainer()->getParameter('ezpublish.siteaccess.default'),
+            'cli'
+        );
     }
 
     /**


### PR DESCRIPTION
> Required by ezsystems/ezpublish-kernel#1401

This matches the default siteaccess from the config instead of a hardcoded one. Makes it possible to run behat with any kind of install.

## TODO
- [x] Cleanup un-used pieces