### PR TITLE
Bug fix: ObjectManager/BasicContent draft support

### DIFF
--- a/ObjectManager/BasicContent.php
+++ b/ObjectManager/BasicContent.php
@@ -42,8 +42,13 @@ class BasicContent extends Base
         $repository = $this->getRepository();
         $languageCode = self::DEFAULT_LANGUAGE;
 
-        $content = $this->createContentDraft($parentLocationId, $contentType, $languageCode, $fields);
-        $content = $repository->getContentService()->publishVersion($content->versionInfo);
+        $content = $this->getRepository()->sudo(
+            function(Repository $repository) use ( $parentLocationId, $contentType, $fields, $languageCode )
+            {
+                $content = $this->createContentDraft($parentLocationId, $contentType, $fields, $languageCode);
+                return $content = $repository->getContentService()->publishVersion($content->versionInfo);
+            }
+        );
 
         return $content->contentInfo->mainLocationId;
     }


### PR DESCRIPTION
PR #34 introduced two minor bugs:
* A call to the method `createContentDraft()` as the wrong parameters order
* A call to the method `createContentDraft()` was not wrapped in a `sudo()`