### PR TITLE
Implement EZP-24925: Extract XmlText field type out of kernel into separate repository

### DIFF
--- a/Context/Object/BasicContent.php
+++ b/Context/Object/BasicContent.php
@@ -63,6 +63,6 @@ trait BasicContent
      */
     private function getDummyXmlText()
     {
-        return '<?xml version="1.0" encoding="utf-8"?><section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"><paragraph>This is a paragraph.</paragraph></section>';
+        return '<?xml version="1.0" encoding="UTF-8"?><section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0"><para>This is a paragraph.</para></section>';
     }
 }


### PR DESCRIPTION
This PR resolves `BehatBundle` part of https://jira.ez.no/browse/EZP-24925

Just some more conversion from XmlText to RichText.