### PR TITLE
POC: Using Behat Extension to inject the required services

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,0 +1,7 @@
+services:
+  behatbundle.context_initializer:
+    class: EzSystems\BehatBundle\ServiceContainer\Initializer\EzBehatInitializer
+    arguments:
+        kernel: @symfony2_extension.kernel
+    tags:
+      -  { name: context.initializer }

--- a/ServiceContainer/EzBehatExtension.php
+++ b/ServiceContainer/EzBehatExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace EzSystems\BehatBundle\ServiceContainer;
+
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Symfony2Extension\ServiceContainer\Driver\SymfonyFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * EzBehatExtension loads extension specific services
+ */
+class EzBehatExtension implements Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigKey()
+    {
+        return 'ezbehatextension';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+
+    /**
+     * Loads extension services into temporary container.
+     *
+     * @param ContainerBuilder $container
+     * @param array $config
+     */
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/ServiceContainer/Initializer/EzBehatInitializer.php
+++ b/ServiceContainer/Initializer/EzBehatInitializer.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace EzSystems\BehatBundle\ServiceContainer\Initializer;
+
+use ReflectionClass;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\Initializer\ContextInitializer;
+
+/**
+ * Behat Context Initializer service
+ */
+class EzBehatInitializer implements ContextInitializer
+{
+    /**
+     * Service annotation tag
+     */
+    const SERVICE_DOC_TAG = 'EzBehatService';
+
+    /**
+     * @var Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param Kernel $kernel
+     */
+    public function __construct($kernel)
+    {
+        $this->container = $kernel->getContainer();
+    }
+
+    /**
+     * Initializes provided context.
+     * Detect all it's methods which use the @EzService
+     * annotation and inject the corresponding services.
+     *
+     * @param Context $context
+     */
+    public function initializeContext(Context $context)
+    {
+        foreach ($this->getGetMethodServices($context) as $methodName => $serviceNames) {
+            // get services
+            $services = [];
+            foreach ($serviceNames as $name) {
+                $services[] = $this->container->get($name);
+            }
+
+            // call method with services as arguments
+            call_user_func_array(array($context, $methodName), $services);
+        }
+    }
+
+    /**
+     * Returns an array with all methods and their service requirements,
+     * if the methods use the service Annotation
+     *
+     * @return array array of methods and their service dependencies
+     */
+    private function getGetMethodServices($object)
+    {
+        $refClass = new ReflectionClass($object);
+        $refMethods = $refClass->getMethods();
+
+        $servicesByMethod = [];
+
+        foreach ($refMethods as $refMethod) {
+            preg_match_all('#@(.*?)\n#s', $refMethod->getDocComment(), $matches);
+            // parse array from (numeric key => 'annotation <value>') to (annotation => value)
+            $methodServices = [];
+            foreach ($matches[1] as $annotation) {
+                $split = preg_split('/[\s]+/', $annotation, 2);
+                $tag = $split[0];
+                $value = isset($split[1]) ? $split[1] : '';
+
+                if ($tag == self::SERVICE_DOC_TAG) {
+                    $methodServices[] = $value;
+                }
+            }
+
+            if (!empty($methodServices)) {
+                $servicesByMethod[$refMethod->name] = $methodServices;
+            }
+        }
+        return $servicesByMethod;
+    }
+}

--- a/doc/Writing Tests.md
+++ b/doc/Writing Tests.md
@@ -78,6 +78,22 @@ For REST interaction there is [REST context](https://github.com/ezsystems/ezpubl
 
 For a completely clean context you don't need anything but Behat/Mink and implement [KernelAwareContext](https://github.com/Behat/Symfony2Extension/blob/master/src/Behat/Symfony2Extension/Context/KernelAwareContext.php) if you need access to kernel (take a look at how it's done in [EzContext](Context/EzContext.php).
 
+##### Accessing eZ Platform / Kernel services
+In order to easily access container services (such as ContentService, SearchService, etc), [EzBehatExtension](ServiceContainer/EzBehatExtension.php) 
+can parse annotations in Behat Contexts and inject the defined services into any method(s), using the following syntax:
+
+``` php
+/**
+ * @EzService ezpublish.api.cool.service
+ * @EzService ezpublish.api.evencooler.service
+ */
+ public function initialize(CoolService $service1, CoolerService $service2)
+ {
+    ...
+ }
+```
+
+
 
 ### Structure
 


### PR DESCRIPTION
The purpose of this POC is to implement a simple and clean way to inject the services required by each of the Contexts without the need for unnecessary dependencies.
This is an alternative to polluting  behat.yml/behat_suites.yml with service declarations for all the contexts, which greatly helps with the readability of the file.
 
With BehatExtension ContextInitializer we can hook logic immediately after the instantiation of each Context, and with the help of Reflection and Annotations we are able to declare inside the Context class the services required.