### PR TITLE
Deprecate Behat classes that will be moved to kernel

### DIFF
--- a/Context/RepositoryContext.php
+++ b/Context/RepositoryContext.php
@@ -14,6 +14,9 @@ use eZ\Publish\Core\Repository\Values\User\UserReference;
 
 /**
  * Repository Context Trait
+ *
+ * @deprecated deprecated since 6.4, will be removed in 7.0.
+ * Use instead EzSystems\PlatformBehatBundle\Context\RepositoryContext
  */
 trait RepositoryContext
 {

--- a/Context/Resolver/AnnotationArgumentResolver.php
+++ b/Context/Resolver/AnnotationArgumentResolver.php
@@ -8,6 +8,9 @@ use Exception;
 
 /**
  * Behat Context Argument Resolver
+ *
+ * @deprecated deprecated since 6.4, will be removed in 7.0.
+ * Use instead EzSystems\PlatformBehatBundle\Context\Argument\AnnotationArgumentResolver
  */
 class AnnotationArgumentResolver implements ArgumentResolver
 {

--- a/ServiceContainer/EzBehatExtension.php
+++ b/ServiceContainer/EzBehatExtension.php
@@ -12,6 +12,9 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /**
  * EzBehatExtension loads extension specific services
+ *
+ * @deprecated deprecated since 6.4, will be removed in 7.0.
+ * Use instead EzSystems\PlatformBehatBundle\ServiceContainer\EzBehatExtension
  */
 class EzBehatExtension implements Extension
 {


### PR DESCRIPTION
As decided BehatBundle is to be deprecated and separated between the kernel and platformUI bundle. The idea is to make the Behat easier to maintain, having less repo dependencies should help releases and versions also.

Added deprecation Doc to the classes to be deprecated in the following PRs:
* https://github.com/ezsystems/ezpublish-kernel/pull/1584
* https://github.com/ezsystems/ezpublish-kernel/pull/1585
* https://github.com/ezsystems/ezpublish-kernel/pull/1586