### PR TITLE
EZS-621: Add waitWhileLoading call to iClickAtButton

### DIFF
--- a/Context/Browser/SubContext/CommonActions.php
+++ b/Context/Browser/SubContext/CommonActions.php
@@ -149,6 +149,7 @@ trait CommonActions
     public function iClickAtButton( $button )
     {
         $this->onPageSectionIClickAtButton( $button );
+        $this->waitWhileLoading();
     }
 
     /**


### PR DESCRIPTION
This PR adds an extra "wait" step to the function responsible for clicking at a button.
I believe this might resolve the issues with timeouts in the Flex Workflow scenario (https://github.com/ezsystems/flex-workflow/pull/30) where this function is also used.