### PR TITLE
Improve unique genarated values for names and identifiers

### DIFF
--- a/Context/Object/User.php
+++ b/Context/Object/User.php
@@ -136,17 +136,6 @@ trait User
     }
 
     /**
-     * @Given there isn't a User with id :id
-     *
-     *Makes user a user with (mapped) id ':id' does not exist
-     */
-    public function iDontHaveUserWithId( $id )
-    {
-        $randomId = $this->findNonExistingUserId();
-        $this->addValuesToKeyMap( $id, $randomId );
-    }
-
-    /**
      * @Given there is a User with name :username with id :id in :parentGroup group
      *
      * Ensures a user with username ':username' and id ':id' exists as a child of ':parentGroup' user group, can create either one.
@@ -354,27 +343,4 @@ trait User
 
         throw new \Exception( 'Possible endless loop when attempting to find a new name for User.' );
     }
-
-    /**
-     * Find an non existent User id
-     *
-     * @return int Non existing id
-     *
-     * @throws \Exception Possible endless loop
-     */
-    private function findNonExistingUserId()
-    {
-        $userManager = $this->getUserManager();
-        for ( $i = 0; $i < 20; $i++ )
-        {
-            $id = uniqid();
-            if ( !$userManager()->checkUserExistenceById( $id ) )
-            {
-                return $id;
-            }
-        }
-
-        throw new \Exception( 'Possible endless loop when attempting to find a new id for User.' );
-    }
-
 }

--- a/Context/Object/User.php
+++ b/Context/Object/User.php
@@ -320,9 +320,10 @@ trait User
             return $email;
         }
 
+        $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $email = 'User#' . rand( 1000, 9999 ) . "@ez.no";
+            $email = $userManager->generateUniqueIdentifier( 'User#', "@ez.no" );
             if ( !$this->getUserManager()->checkUserExistenceByEmail( $email ) )
             {
                 return $email;
@@ -341,10 +342,11 @@ trait User
      */
     private function findNonExistingUserName()
     {
+        $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $username = 'User#' . rand( 1000, 9999 );
-            if ( !$this->getUserManager()->checkUserExistenceByUsername( $username ) )
+            $username = $userManager->generateUniqueIdentifier( 'User#' );
+            if ( !$userManager->checkUserExistenceByUsername( $username ) )
             {
                 return $username;
             }
@@ -362,9 +364,10 @@ trait User
      */
     private function findNonExistingUserId()
     {
+        $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $id = rand( 1000, 9999 );
+            $id = $userManager->generateUniqueIdentifier();
             if ( !$this->getUserManager()->checkUserExistenceById( $id ) )
             {
                 return $id;

--- a/Context/Object/User.php
+++ b/Context/Object/User.php
@@ -314,17 +314,17 @@ trait User
      */
     private function findNonExistingUserEmail( $username = 'User' )
     {
+        $userManager = $this->getUserManager();
         $email = "${username}@ez.no";
-        if ( $this->getUserManager()->checkUserExistenceByEmail( $email ) )
+        if ( $userManager->checkUserExistenceByEmail( $email ) )
         {
             return $email;
         }
 
-        $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $email = $userManager->generateUniqueIdentifier( 'User#', "@ez.no" );
-            if ( !$this->getUserManager()->checkUserExistenceByEmail( $email ) )
+            $email = 'User#'. uniqid() . '@ez.no';
+            if ( !$userManager->checkUserExistenceByEmail( $email ) )
             {
                 return $email;
             }
@@ -345,7 +345,7 @@ trait User
         $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $username = $userManager->generateUniqueIdentifier( 'User#' );
+            $username = 'User#'. uniqid();
             if ( !$userManager->checkUserExistenceByUsername( $username ) )
             {
                 return $username;
@@ -367,8 +367,8 @@ trait User
         $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $id = $userManager->generateUniqueIdentifier();
-            if ( !$this->getUserManager()->checkUserExistenceById( $id ) )
+            $id = uniqid();
+            if ( !$userManager()->checkUserExistenceById( $id ) )
             {
                 return $id;
             }

--- a/Context/Object/UserGroup.php
+++ b/Context/Object/UserGroup.php
@@ -77,18 +77,6 @@ trait UserGroup
     }
 
     /**
-     * @Given there isn't a User Group with id :id
-     *
-     * Maps id ':id' to a non-existent user group.
-     */
-    public function iDontHaveUserGroupWithId( $id )
-    {
-        $randomId = $this->findNonExistingUserGroupId();
-
-        $this->addValuesToKeyMap( $id, $randomId );
-    }
-
-    /**
      * @Given there is a User Group with name :name with id :id in :parentGroup group
      *
      * Ensures a user group with name ':name' exists as a child of group ':parentGroup', mapping it's id to ':id'
@@ -195,27 +183,5 @@ trait UserGroup
         }
 
         throw new \Exception( 'Possible endless loop when attempting to find a new id for UserGroup.' );
-    }
-
-    /**
-     * Find a non existing UserGroup name
-     *
-     * @return string A not used name
-     *
-     * @throws \Exception Possible endless loop
-     */
-    private function findNonExistingUserGroupName()
-    {
-        $userGoupManager = $this->getUserGroupManager();
-        for ( $i = 0; $i < 20; $i++ )
-        {
-            $name = 'UserGroup#'. uniqid();
-            if ( !$userGoupManager->checkUserGroupExistenceByName( $name ) )
-            {
-                return $name;
-            }
-        }
-
-        throw new \Exception( 'Possible endless loop when attempting to find a new name for UserGroup.' );
     }
 }

--- a/Context/Object/UserGroup.php
+++ b/Context/Object/UserGroup.php
@@ -184,9 +184,10 @@ trait UserGroup
      */
     private function findNonExistingUserGroupId()
     {
+        $userGoupManager = $this->getUserGroupManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $id = rand( 1000, 9999 );
+            $id = $userGoupManager->generateUniquedentifier();
             if ( !$this->getUserGroupManager()->checkUserGroupExistence( $id ) )
             {
                 return $id;
@@ -205,10 +206,11 @@ trait UserGroup
      */
     private function findNonExistingUserGroupName()
     {
+        $userGoupManager = $this->getUserGroupManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $name = 'UserGroup#' . rand( 1000, 9999 );
-            if ( !$this->getUserGroupManager()->checkUserGroupExistenceByName( $name ) )
+            $name = $userGoupManager->generateUniquedentifier( 'UserGroup#' );
+            if ( !$userGoupManager->checkUserGroupExistenceByName( $name ) )
             {
                 return $name;
             }

--- a/Context/Object/UserGroup.php
+++ b/Context/Object/UserGroup.php
@@ -187,8 +187,8 @@ trait UserGroup
         $userGoupManager = $this->getUserGroupManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $id = $userGoupManager->generateUniquedentifier();
-            if ( !$this->getUserGroupManager()->checkUserGroupExistence( $id ) )
+            $id = uniqid();
+            if ( !$userGroupManager()->checkUserGroupExistence( $id ) )
             {
                 return $id;
             }
@@ -209,7 +209,7 @@ trait UserGroup
         $userGoupManager = $this->getUserGroupManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $name = $userGoupManager->generateUniquedentifier( 'UserGroup#' );
+            $name = 'UserGroup#'. uniqid();
             if ( !$userGoupManager->checkUserGroupExistenceByName( $name ) )
             {
                 return $name;

--- a/ObjectManager/Base.php
+++ b/ObjectManager/Base.php
@@ -135,17 +135,4 @@ abstract class Base implements ObjectManagerInterface
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object Object that should be destroyed/removed
      */
     abstract protected function destroy( ValueObject $object );
-
-    /**
-     * Generates a random name based on prefix and postfix, if one or both are are given
-     *
-     * @param string $prefix
-     * @param string $postfix
-     *
-     * @return string
-     */
-    public function generateUniqueIdentifier( $prefix = '', $postfix = '' )
-    {
-        return uniqid($prefix) . $postfix;
-    }
 }

--- a/ObjectManager/Base.php
+++ b/ObjectManager/Base.php
@@ -135,4 +135,17 @@ abstract class Base implements ObjectManagerInterface
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object Object that should be destroyed/removed
      */
     abstract protected function destroy( ValueObject $object );
+
+    /**
+     * Generates a random name based on prefix and postfix, if one or both are are given
+     *
+     * @param string $prefix
+     * @param string $postfix
+     *
+     * @return string
+     */
+    public function generateUniqueIdentifier( $prefix = '', $postfix = '' )
+    {
+        return $prefix . str_replace( ['.', ' '], '', microtime() ) . $postfix;
+    }
 }

--- a/ObjectManager/Base.php
+++ b/ObjectManager/Base.php
@@ -146,6 +146,6 @@ abstract class Base implements ObjectManagerInterface
      */
     public function generateUniqueIdentifier( $prefix = '', $postfix = '' )
     {
-        return $prefix . str_replace( ['.', ' '], '', microtime() ) . $postfix;
+        return uniqid($prefix) . $postfix;
     }
 }

--- a/ObjectManager/FieldType.php
+++ b/ObjectManager/FieldType.php
@@ -315,7 +315,7 @@ class FieldType extends Base
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
         $name = $this->fieldConstructionObject[ 'fieldType' ]->identifier;
-        $name .= "#" . rand( 1000, 9000 );
+        $name = $this->generateUniqueName( $name . "#" );
         $identifier = strtolower( $name );
         $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct( $identifier );
         $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;

--- a/ObjectManager/FieldType.php
+++ b/ObjectManager/FieldType.php
@@ -306,7 +306,6 @@ class FieldType extends Base
         return $this->fieldConstructionObject[ 'content' ]->id;
     }
 
-
     /**
      * Creates an instance of a contenttype and stores it for later publishing
      */
@@ -315,7 +314,7 @@ class FieldType extends Base
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
         $name = $this->fieldConstructionObject[ 'fieldType' ]->identifier;
-        $name = $this->generateUniqueName( $name . "#" );
+        $name = $name . '#' . uniqid();
         $identifier = strtolower( $name );
         $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct( $identifier );
         $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;


### PR DESCRIPTION
Random numbers used for names and identifiers were being generated with a small interval which caused collisions sometimes resulting in test failures.  Before we were using the `rand` function and now we use the `uniqid` function to generate the unique identifiers, this should make collision extremely rare or not happen at all.
