### PR TITLE
Add Textline fieldtype support for Behat tests

### DIFF
--- a/Context/Object/FieldType.php
+++ b/Context/Object/FieldType.php
@@ -61,13 +61,16 @@ trait FieldType
         $this->getFieldTypeManager()->createField( $fieldType, $name );
         foreach ( $properties as $property )
         {
-            if ( $property[ 'Validator' ] == 'maximum value validator' )
+            switch( $property[ 'Validator' ] )
             {
-                $this->getFieldTypeManager()->addValueConstraint( $fieldType, $property[ 'Value' ], "max" );
-            }
-            else if ( $property[ 'Validator' ] == 'minimum value validator' )
-            {
-                $this->getFieldTypeManager()->addValueConstraint( $fieldType, $property[ 'Value' ], "min" );
+                case 'maximum value validator':
+                case 'maximum length validator':
+                    $this->getFieldTypeManager()->addValueConstraint( $fieldType, $property[ 'Value' ], "max" );
+                    break;
+                case 'minimum value validator':
+                case 'minimum length validator':
+                    $this->getFieldTypeManager()->addValueConstraint( $fieldType, $property[ 'Value' ], "min" );
+                    break;
             }
         }
     }

--- a/ObjectManager/FieldType.php
+++ b/ObjectManager/FieldType.php
@@ -44,21 +44,24 @@ class FieldType extends Base
      * @var array Stores Internal mapping of the fieldType names
      */
     private $fieldTypeInternalIdentifier = array(
-        "integer" => "ezinteger"
+        "integer" => "ezinteger",
+        "text line" => "ezstring",
     );
 
     /**
      * @var array Maps the validator of the fieldtypes
      */
     private $validatorMappings = array(
-        "integer" => "IntegerValue"
+        "integer" => "IntegerValue",
+        "text line" => "StringLength",
     );
 
     /**
      * @var array Maps the default values of the fieldtypes
      */
     private $defaultValues = array(
-        "integer" => 1
+        "integer" => 1,
+        "text line" => "test",
     );
 
     /**


### PR DESCRIPTION
Add Textline fieldtype default values, internal name and validator support in Fields Context. Required to run test related to Textline fields.