### PR TITLE
EZP-24842: [PostgreSQL] Fixed identifier letters case inconsistencies

### DIFF
--- a/Context/EzContext.php
+++ b/Context/EzContext.php
@@ -254,7 +254,8 @@ class EzContext implements KernelAwareContext
         $role = $this->getRepository()->sudo(
             function() use ( $roleService, $roleIdentifier )
             {
-                return $roleService->loadRoleByIdentifier( $roleIdentifier );
+                // make sure role name starts with uppercase as this is what default setup provides
+                return $roleService->loadRoleByIdentifier(ucfirst($roleIdentifier));
             }
         );
 

--- a/Context/EzContext.php
+++ b/Context/EzContext.php
@@ -255,6 +255,13 @@ class EzContext implements KernelAwareContext
             function() use ( $roleService, $roleIdentifier )
             {
                 // make sure role name starts with uppercase as this is what default setup provides
+                if ($roleIdentifier !== ucfirst($roleIdentifier)) {
+                    @trigger_error(
+                        "'{$roleIdentifier}' role name should start with uppercase letter",
+                        E_USER_DEPRECATED
+                    );
+                }
+
                 return $roleService->loadRoleByIdentifier(ucfirst($roleIdentifier));
             }
         );

--- a/Context/Object/ContentType.php
+++ b/Context/Object/ContentType.php
@@ -124,7 +124,7 @@ class ContentType implements Context
     {
         Assertion::assertTrue(
             $this->checkContentTypeExistenceByIdentifier($identifier, $groupIdentifier),
-            "Couldn't find Content Type with identifier '$identifier' on '$groupIdentifier."
+            "Couldn't find Content Type with identifier '$identifier' on '$groupIdentifier'."
         );
     }
 
@@ -240,6 +240,9 @@ class ContentType implements Context
      */
     protected function checkContentTypeExistenceByIdentifier($identifier, $groupIdentifier = null)
     {
+        // @see ensureContentTypeWithIdentifier
+        $identifier = strtolower($identifier);
+
         $contentType = $this->loadContentTypeByIdentifier($identifier, false);
         if ($contentType && $groupIdentifier) {
             $contentTypeGroups = $contentType->getContentTypeGroups();

--- a/ObjectManager/Role.php
+++ b/ObjectManager/Role.php
@@ -38,11 +38,13 @@ class Role extends Base
                 $roleService = $repository->getRoleService();
                 try
                 {
-                    $role = $roleService->loadRoleByIdentifier( $name );
+                    // make sure role name starts with uppercase as this is what default setup provides
+                    $role = $roleService->loadRoleByIdentifier(ucfirst($name));
                 }
                 catch ( ApiExceptions\NotFoundException $e )
                 {
-                    $roleCreateStruct = $roleService->newRoleCreateStruct( $name );
+                    // make sure role name starts with uppercase as this is what default setup provides
+                    $roleCreateStruct = $roleService->newRoleCreateStruct(ucfirst($name));
                     $roleDraft = $roleService->createRole( $roleCreateStruct );
                     $roleService->publishRoleDraft($roleDraft);
                     $role = $roleService->loadRole($roleDraft->id);
@@ -74,7 +76,8 @@ class Role extends Base
                 $roleService = $repository->getRoleService();
                 try
                 {
-                    $role = $roleService->loadRoleByIdentifier( $identifier );
+                    // make sure role name starts with uppercase as this is what default setup provides
+                    $role = $roleService->loadRoleByIdentifier(ucfirst($identifier));
                 }
                 catch ( ApiExceptions\NotFoundException $e )
                 {

--- a/ObjectManager/Role.php
+++ b/ObjectManager/Role.php
@@ -36,14 +36,21 @@ class Role extends Base
             {
                 $role = null;
                 $roleService = $repository->getRoleService();
+
+                // make sure role name starts with uppercase as this is what default setup provides
+                if ($name !== ucfirst($name)) {
+                    @trigger_error(
+                        "'{$name}' role name should start with uppercase letter",
+                        E_USER_DEPRECATED
+                    );
+                }
+
                 try
                 {
-                    // make sure role name starts with uppercase as this is what default setup provides
                     $role = $roleService->loadRoleByIdentifier(ucfirst($name));
                 }
                 catch ( ApiExceptions\NotFoundException $e )
                 {
-                    // make sure role name starts with uppercase as this is what default setup provides
                     $roleCreateStruct = $roleService->newRoleCreateStruct(ucfirst($name));
                     $roleDraft = $roleService->createRole( $roleCreateStruct );
                     $roleService->publishRoleDraft($roleDraft);
@@ -77,6 +84,12 @@ class Role extends Base
                 try
                 {
                     // make sure role name starts with uppercase as this is what default setup provides
+                    if ($identifier !== ucfirst($identifier)) {
+                        @trigger_error(
+                            "'{$identifier}' role name should start with uppercase letter",
+                            E_USER_DEPRECATED
+                        );
+                    }
                     $role = $roleService->loadRoleByIdentifier(ucfirst($identifier));
                 }
                 catch ( ApiExceptions\NotFoundException $e )


### PR DESCRIPTION
Unblocks [EZP-24842](https://jira.ez.no/browse/EZP-24842)
----

While executing Behat scenarios for eZ Platform running on PostgreSQL (see  [EZP-24842](https://jira.ez.no/browse/EZP-24842)) I've found some inconsistencies in identifier letters case and I've chosen simplest way to fix them. 

Though this is related to `v2` support of PostgreSQL, we can fix it without risk for current version of this bundle as eZ Platform `2.0` also uses it and for MySQL due to `utf8_general_ci` collation it does not matter.

**TODO**:
- [x] Ensure Role name always starts with uppercase character.
*all scenarios use `administrator` Role name while default setup provides `Administrator` Role, which matters for PostgreSQL*
- [x] Align lower-cased Content Type identifier when checking Content Type existence. *`Context\Object\ContentType::ensureContentTypeWithIdentifier` creates Content Type with lower-cased identifier, while `checkContentTypeExistenceByIdentifier` ignores that fact*