### PR TITLE
EZP-25780: Ignore PHP warnings when clearing cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
+# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
 dist: trusty
 sudo: required
 
 language: php
 
-# Make sure these are running as we need them (mysql is temprary needed as we do first part of instal using local setup)
 services:
   - mysql
-  - docker
 
 # Mysql isn't installed on trusty (only client is), so we need to specifically install it
 addons:
@@ -22,47 +21,44 @@ cache:
 
 env:
   global:
+    # For functional tests
     - COMPOSE_FILE="doc/docker-compose/base-dev.yml:doc/docker-compose/selenium.yml"
-    - RUN_INSTALL=1
-    - SYMFONY_ENV=behat
-    - PLATFORM_BRANCH=master
+    - EZPLATFORM_BRANCH=master
+    - RUN_INSTALL=1 
+    - SYMFONY_ENV=behat 
+    - SYMFONY_DEBUG=1
+    - SETUP_SCRIPT=./bin/.travis/prepare_behat_v2.sh
 
 matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: BEHAT_OPTS="--profile=behat --suite=default --tags='~@broken'"
+      env: BEHAT_OPTS="--profile=behat --suite=default --tags='~@broken'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - php: 7.1
-      env: BEHAT_OPTS="--profile=rest --suite=fullJson --tags='~@broken'"
+      env: BEHAT_OPTS="--profile=rest --suite=fullJson --tags='~@broken'" COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
     - php: 5.6
-      env: BEHAT_OPTS="--profile=rest --suite=fullXml --tags='~@broken'" PHP_IMAGE=ezsystems/php:5.6-v1 PHP_IMAGE_DEV=ezsystems/php:5.6-v1-dev PLATFORM_BRANCH=1.13
+      env: BEHAT_OPTS="--profile=rest --suite=fullXml --tags='~@broken'" SETUP_SCRIPT=./bin/.travis/prepare_behat.sh PHP_IMAGE=ezsystems/php:5.6-v1 PHP_IMAGE_DEV=ezsystems/php:5.6-v1-dev EZPLATFORM_BRANCH=1.13
+    - php: 5.6
+      env: BEHAT_OPTS="--profile=rest --suite=fullJson --tags='~@broken'" SETUP_SCRIPT=./bin/.travis/prepare_behat.sh PHP_IMAGE=ezsystems/php:5.6-v1 PHP_IMAGE_DEV=ezsystems/php:5.6-v1-dev EZPLATFORM_BRANCH=1.13
 
-# test only master (+ Pull requests)
+# test only master and pull requests
 branches:
   only:
     - master
 
-# Setup system for behat testing
-before_script:
-  # Change local git repo to be a full one as we will reuse current checkout for composer install below
-  - git fetch --unshallow && git checkout -b tmp_ci_branch
-  - export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR
-  - export TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
-  - cd "$HOME/build"
+# setup requirements for running Behat tests
+before_install:
+  # Disable memory_limit for composer in PHP 5.6
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/5.6/etc/conf.d/travis.ini
+  - eval $SETUP_SCRIPT
 
-  # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-  - git clone --depth 1 --single-branch --branch $PLATFORM_BRANCH https://github.com/ezsystems/ezplatform.git
-  - cd ezplatform
-
-  # Install everything needed for behat testing, using our local branch of this repo
-  - ./bin/.travis/trusty/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/behatbundle:dev-tmp_ci_branch"
-
-# execute behat as the script command
+# execute phpunit or behat as the script command
 script:
-  - cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS"
+  - cd "$HOME/build/ezplatform";
+  - docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS"
 
-# disable mail notifications
-notification:
+# disable mail notifications		
+notification:		
   email: false
 
 # reduce depth (history) of git checkout

--- a/ObjectManager/Role.php
+++ b/ObjectManager/Role.php
@@ -111,6 +111,10 @@ class Role extends Base
      */
     protected function destroy( ValueObject $object )
     {
+        // Ignore warnings about not empty cache directory. See: https://github.com/ezsystems/BehatBundle/pull/71
+        $currentErrorReportingLevel = error_reporting();
+        error_reporting($currentErrorReportingLevel & ~E_WARNING);
+
         /** @var \eZ\Publish\API\Repository\Repository $repository */
         $repository = $this->getRepository();
         $repository->sudo(
@@ -128,5 +132,7 @@ class Role extends Base
                 }
             }
         );
+
+        error_reporting($currentErrorReportingLevel);
     }
 }

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# File for setting up system for behat testing, just like it's done in Kernel's .travis.yml
+
+# Change local git repo to be a full one as we will reuse it for composer install below
+git fetch --unshallow && git checkout -b tmp_ci_branch
+export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
+
+cd "$HOME/build"
+
+git clone --depth 1 --single-branch --branch $EZPLATFORM_BRANCH https://github.com/ezsystems/ezplatform.git
+cd ezplatform
+
+# Install everything needed for behat testing, using our local branch of this repo
+./bin/.travis/trusty/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/BehatBundle:dev-tmp_ci_branch"

--- a/bin/.travis/prepare_behat_v2.sh
+++ b/bin/.travis/prepare_behat_v2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PACKAGE_BUILD_DIR=$PWD
+EZPLATFORM_BUILD_DIR=${HOME}/build/ezplatform
+
+echo "> Cloning ezsystems/ezplatform:${EZPLATFORM_BRANCH}"
+git clone --depth 1 --single-branch --branch $EZPLATFORM_BRANCH https://github.com/ezsystems/ezplatform.git ${EZPLATFORM_BUILD_DIR}
+cd ${EZPLATFORM_BUILD_DIR}
+
+/bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" '' "${PACKAGE_BUILD_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "target-dir": "EzSystems/BehatBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "6.5.x-dev"
+            "dev-master": "6.5.x-dev",
+            "dev-tmp_ci_branch": "6.5.x-dev"
         }
     }
 }


### PR DESCRIPTION
JIRA Ticket: https://jira.ez.no/browse/EZP-25780

Looks like Stash has problems with concurrent operations happening in Filesystem cache, it was reported to them: https://github.com/tedious/Stash/issues/359 (also, similar issue: https://jira.ez.no/browse/EZP-29257)

Given that:
1) this issue occurs only in tests for us
2) The main purpose of the test (it's possible to delete a Role using PlatformUI) is still met (and tested)
3) it was reported more than 2 years ago

I think we can silence this warning. Handling it is important, because it causes PlatformUI 1.7 and 1.13 tests to randomly fail, which decreases the efficiency of our CI.

~~It's `WIP`, because I still have to test it on Travis.~~ I've used https://github.com/ezsystems/PlatformUIBundle/pull/988 for testing.

First commit is the actual change, second commit fixes CI build (it's currently failing).