### PR TITLE
Removed the dot in Content Type identifier

### DIFF
--- a/ObjectManager/FieldType.php
+++ b/ObjectManager/FieldType.php
@@ -315,6 +315,7 @@ class FieldType extends Base
         $contentTypeService = $repository->getContentTypeService();
         $name = $this->fieldConstructionObject[ 'fieldType' ]->identifier;
         $name = uniqid($name . '#', true);
+        $name = str_replace('.', '', $name);
         $identifier = strtolower( $name );
         $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct( $identifier );
         $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;


### PR DESCRIPTION
The generated name is used as Content Type identifier, which cannot contain the `.` symbol. 

Using the dot breaks AdminUI tests, which use BehatBundle to create Content Types - example failure: https://res.cloudinary.com/ezplatformtravis/image/upload/v1547823290/screenshots/vendor_ezsystems_ezplatform-admin-ui_features_contenttypefields_feature_24_wwqmm1.png