### PR TITLE
Do not generate usernames longer than 15 characters

### DIFF
--- a/Context/Object/User.php
+++ b/Context/Object/User.php
@@ -341,7 +341,7 @@ trait User
         $userManager = $this->getUserManager();
         for ( $i = 0; $i < 20; $i++ )
         {
-            $username = uniqid('User#', true);
+            $username = substr(uniqid('User#', true), 0, 15);
             if ( !$userManager->checkUserExistenceByUsername( $username ) )
             {
                 return $username;


### PR DESCRIPTION
The recent changes in BehatBundle (https://github.com/ezsystems/BehatBundle/pull/72) uncovered an issue in PlatformUI: https://jira.ez.no/browse/EZP-30186

This is causing the current 1.7 builds to fail, for example: https://travis-ci.org/ezsystems/ezplatform/jobs/499512773

Screenshot from Travis: https://res.cloudinary.com/ezplatformtravis/image/upload/v1551311404/screenshots/5c77222c73287811074211-vendor_ezsystems_platform-ui-bundle_features_users_users_feature_7_acbp3s.png

I think that the priority of this issue is rather low (1.7 has been released long time ago and nobody reported it), so for me it makes sense to adjust the tests and generate shorter usernames (and unblock the build so that we will be notified when something serious happens).

Uniqid with more_entropy is guaranteed to generate a string consisting of 23 characters, there is no need to check for the length here.
```
With an empty prefix, the returned string will be 13 characters long. If more_entropy is TRUE, it will be 23 characters.
```