### PR TITLE
Change passwords used in tests

### DIFF
--- a/Context/EzContext.php
+++ b/Context/EzContext.php
@@ -272,7 +272,7 @@ class EzContext implements KernelAwareContext
 
         // create a new user, uses 'User' trait
         $username = $this->findNonExistingUserName();
-        $password = $username;
+        $password = $this->getUserManager()->getDefaultPassword();
         $email = "${username}@ez.no";
         $user = $this->getUserManager()->ensureUserExists( $username, $email, $password );
 

--- a/Context/Object/User.php
+++ b/Context/Object/User.php
@@ -27,7 +27,7 @@ trait User
     public function iHaveUser( $username )
     {
         $email = $this->findNonExistingUserEmail( $username );
-        $password = $username;
+        $password = $this->getUserManager()->getDefaultPassword();
         $user = $this->getUserManager()->ensureUserExists( $username, $email, $password );
         $this->addValuesToKeyMap( $email, $user->email );
     }
@@ -54,7 +54,7 @@ trait User
     public function iHaveUserInGroup( $username, $parentGroupName )
     {
         $email = $this->findNonExistingUserEmail( $username );
-        $password = $username;
+        $password = $this->getUserManager()->getDefaultPassword();
         $user = $this->getUserManager()->ensureUserExists( $username, $email, $password, $parentGroupName );
         $this->addValuesToKeyMap( $email, $user->email );
     }

--- a/Features/user.feature
+++ b/Features/user.feature
@@ -43,13 +43,13 @@ Feature: User Creation
         Given there is a User with name "testuser" with the following fields:
             | Name          | value           |
             | email         | testuser@ez.no  |
-            | password      | testuser        |
+            | password      | PassWord42      |
             | first_name    | Test            |
             | last_name     | User            |
         Then User with name "testuser" exists
         And User with name "testuser" has the following fields:
             | Name          | value           |
             | email         | testuser@ez.no  |
-            | password      | testuser        |
+            | password      | PassWord42      |
             | first_name    | Test            |
             | last_name     | User            |

--- a/ObjectManager/User.php
+++ b/ObjectManager/User.php
@@ -44,6 +44,16 @@ class User extends Base
     }
 
     /**
+     * Returns a default password that passes validation
+     *
+     * @return string
+     */
+    public function getDefaultPassword()
+    {
+        return 'PassWord42';
+    }
+
+    /**
      * Search User Groups with given name
      *
      * @param string $name name of User Group to search for


### PR DESCRIPTION
After https://github.com/ezsystems/ezpublish-kernel/pull/2570 the repository-forms tests started failing with:
```
    And there is a User with name "testuser" in "Members" group             # EzSystems\BehatBundle\Context\EzContext::iHaveUserInGroup()
      eZ\Publish\Core\Base\Exceptions\UserPasswordValidationException: Argument 'password' is invalid: Password doesn't match the following rules: User password must be at least 10 characters long, User password must include at least one upper case letter, User password must include at least one number in vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/UserService.php:426
      Stack trace:
```
(https://travis-ci.org/ezsystems/ezplatform/jobs/509658540)

as the password equal to username does not meet the requirements. Adjusting it so that it passes.
