### PR TITLE
EZP-30540: Add ability to manage configuration using BehatBundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   include:
     - name: "Code Style Check"
       env: CHECK_CS=1
+    - name: "Unit tests"
+      env: PHPUNIT_CONFIG='phpunit.xml'
     - name: "Behat tests"
       php: 7.1
       env: BEHAT_OPTS="--profile=behat --suite=examples"
@@ -50,10 +52,11 @@ before_install:
 
 install:
   # Install packages if needed
-  - if [ "${CHECK_CS}" == "1" ]; then travis_retry composer install --prefer-dist --no-interaction --no-suggest ; fi
+  - if [ "${CHECK_CS}" == "1" -o "${PHPUNIT_CONFIG}" != "" ]; then travis_retry composer install --prefer-dist --no-interaction --no-suggest ; fi
   # Prepare whole environment if needed
   - if [ "${BEHAT_OPTS}" != "" ]; then ./bin/.travis/prepare_ezplatform.sh ; fi
 
 script:
   - if [ "${CHECK_CS}" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating ; fi
+  - if [ "${PHPUNIT_CONFIG}" != '' ]; then ./vendor/bin/phpunit -c "${PHPUNIT_CONFIG}"; fi
   - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -2,7 +2,7 @@ behat:
     suites:
         examples:
             paths:
-                - '%paths.base%/vendor/ezsystems/behatbundle/features/examples.feature'
+                - '%paths.base%/vendor/ezsystems/behatbundle/features/'
             contexts:
               - EzSystems\Behat\API\Context\TestContext:
                   userService: '@ezpublish.api.service.user'
@@ -17,3 +17,5 @@ behat:
                   roleFacade: '@ezbehatbundle.api.facade.rolefacade'
               - EzSystems\Behat\API\Context\LanguageContext:
                   languageFacade: '@ezbehatbundle.api.facade.languagefacade'
+              - EzSystems\Behat\Core\Context\ConfigurationContext:
+                  projectDir: '%paths.base%'

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+require_once __DIR__ . '/vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,24 @@
     "require": {
         "php": "^7.1",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
-        "phpunit/phpunit": "^5.7|^6.0|^7.0",
         "fzaninotto/faker": "^1.8",
-        "behat/behat": "^3.4"
+        "behat/behat": "^3.4",
+        "symfony/property-access": "^3.0",
+        "symfony/yaml": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.15.0"
+        "friendsofphp/php-cs-fixer": "~2.15.0",
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
             "EzSystems\\BehatBundle\\": "src/bundle/",
             "EzSystems\\Behat\\": "src/lib/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "EzSystems\\Behat\\Test\\": "tests/"
         }
     },
     "scripts": {

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -1,0 +1,63 @@
+Feature: Example scenarios showing how to set configuration
+
+  @admin
+  Scenario: Add a language. Create a siteaccess using it and add it to PageBuilder
+    Given Language "Polski" with code "pol-PL" exists
+    And I add a siteaccess "pol" to "site_group" with settings
+     | key       | value         |
+     | languages | pol-PL,eng-GB |
+    And I append configuration to "admin_group" siteaccess
+      | key                          | value  |
+      | languages                    | pol-PL |
+      | page_builder.siteaccess_list | pol    |
+
+  Scenario: Create specified workflows
+    And I set configuration to "admin" siteaccess under "workflows" key
+    """
+      article_workflow:
+          name: 'Article Workflow'
+          matchers:
+              content_type: article
+          stages:
+              draft:
+                  label: 'Draft'
+                  color: '#4a69bd'
+              done:
+                  color: '#0f0'
+                  last_stage: true
+          initial_stage: draft
+          transitions:
+              done:
+                  from: draft
+                  to: done
+                  icon: '/bundles/ezplatformadminui/img/ez-icons.svg#approved'
+                  label: 'Back to Done'
+              back_to_draft:
+                  reverse: done
+                  icon: '/bundles/ezplatformadminui/img/ez-icons.svg#rejected'
+                  label: 'Back to Draft'
+    """
+    And I append configuration to "admin" siteaccess under "workflows" key
+    """
+    folder_workflow:
+        name: 'Folder Workflow'
+        matchers:
+            content_type: folder
+        stages:
+            draft:
+                label: 'Draft'
+                color: '#0f0'
+            done:
+                color: '#4a69bd'
+                last_stage: true
+        initial_stage: draft
+        transitions:
+            done:
+                from: draft
+                to: done
+                icon: '/bundles/ezplatformadminui/img/ez-icons.svg#approved'
+            back_to_draft:
+                reverse: done
+                icon: '/bundles/ezplatformadminui/img/ez-icons.svg#rejected'
+                label: 'Back to Draft'
+    """

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        colors="true">
+    <testsuites>
+        <testsuite name="EzSystems\BehatBundle">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
             autowire: true
             public: true
 
-    EzSystems\Behat\:
-        resource: '../../../../src/lib/*'
+    EzSystems\Behat\API\:
+        resource: '../../../../src/lib/API/*'
 
     _instanceof:
         EzSystems\Behat\API\Context\LimitationParser\LimitationParserInterface:

--- a/src/lib/Core/Configuration/ConfigurationEditor.php
+++ b/src/lib/Core/Configuration/ConfigurationEditor.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Configuration;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Yaml\Yaml;
+
+class ConfigurationEditor
+{
+    /**
+     * Appends given value under key, extending existing settings.
+     *
+     * @param $config YAML config
+     * @param string $key 'key' or 'nested.key'
+     * @param string|array $value
+     *
+     * @return mixed YAML config
+     */
+    public function append($config, string $key, $value)
+    {
+        $this->modifyValue($config, $key, $value, true);
+
+        return $config;
+    }
+
+    /**
+     * Sets given value under key. Existing settings are overwritten.
+     *
+     * @param $config YAML config
+     * @param string $key 'key' or 'nested.key'
+     * @param string|array $value
+     *
+     * @return mixed YAML config
+     */
+    public function set($config, string $key, $value)
+    {
+        $this->modifyValue($config, $key, $value, false);
+
+        return $config;
+    }
+
+    private function modifyValue(&$config, string $key, $value, bool $appendToExisting): void
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $key = $this->parseKey($key);
+        $currentValue = $propertyAccessor->getValue($config, $key);
+
+        $newValue = $this->getNewValue($currentValue, $value, $appendToExisting);
+        $propertyAccessor->setValue($config, $key, $newValue);
+    }
+
+    private function parseKey(string $key): string
+    {
+        $keys = explode('.', $key);
+        $parsed = '';
+        foreach ($keys as $keyPart) {
+            $parsed .= sprintf('[%s]', $keyPart);
+        }
+
+        return $parsed;
+    }
+
+    private function getNewValue($currentValue, $value, bool $appendToExisting)
+    {
+        if (!$appendToExisting) {
+            return $value;
+        }
+
+        if ($currentValue === null) {
+            return \is_array($value) ? $value : [$value];
+        }
+
+        if (!\is_array($currentValue)) {
+            $currentValue = [$currentValue];
+        }
+
+        if (!\is_array($value)) {
+            $value = [$value];
+        }
+
+        return array_merge($currentValue, $value);
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @return mixed YAML config
+     */
+    public function getConfigFromFile(string $filePath)
+    {
+        return Yaml::parse(file_get_contents($filePath));
+    }
+
+    /**
+     * @param $filePath
+     * @param $config YAML config
+     */
+    public function saveConfigToFile($filePath, $config): void
+    {
+        file_put_contents($filePath, Yaml::dump($config, 8, 5));
+    }
+}

--- a/src/lib/Core/Context/ConfigurationContext.php
+++ b/src/lib/Core/Context/ConfigurationContext.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Exception;
+use EzSystems\Behat\Core\Configuration\ConfigurationEditor;
+use Symfony\Component\Yaml\Yaml;
+
+class ConfigurationContext implements Context
+{
+    private const SITEACCESS_KEY_FORMAT = 'ezpublish.system.%s.%s';
+
+    private $ezplatformConfigFilePath;
+
+    public function __construct(string $projectDir)
+    {
+        $this->ezplatformConfigFilePath = sprintf('%s/app/config/ezplatform.yml', $projectDir);
+    }
+
+    /**
+     * @Given I add a siteaccess :siteaccessName to :siteaccessGroup with settings
+     */
+    public function iAddSiteaccessWithSettings($siteaccessName, $siteaccessGroup, TableNode $settings)
+    {
+        $configurationEditor = new ConfigurationEditor();
+
+        $config = $configurationEditor->getConfigFromFile($this->ezplatformConfigFilePath);
+
+        $config = $configurationEditor->append($config, 'ezpublish.siteaccess.list', $siteaccessName);
+        $config = $configurationEditor->append($config, sprintf('ezpublish.siteaccess.groups.%s', $siteaccessGroup), $siteaccessName);
+
+        foreach ($settings->getHash() as $setting) {
+            $key = $setting['key'];
+            $value = $this->parseSetting($setting['value']);
+            $config = $configurationEditor->set($config, sprintf(self::SITEACCESS_KEY_FORMAT, $siteaccessName, $key), $value);
+        }
+
+        $configurationEditor->saveConfigToFile($this->ezplatformConfigFilePath, $config);
+    }
+
+    /**
+     * @Given I append configuration to :siteaccessName siteaccess
+     */
+    public function iAppendConfigurationToSiteaccess($siteaccessName, TableNode $settings)
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $config = $configurationEditor->getConfigFromFile($this->ezplatformConfigFilePath);
+
+        foreach ($settings->getHash() as $setting) {
+            $key = $setting['key'];
+            $value = $this->parseSetting($setting['value']);
+            $config = $configurationEditor->append($config, sprintf(self::SITEACCESS_KEY_FORMAT, $siteaccessName, $key), $value);
+        }
+
+        $configurationEditor->saveConfigToFile($this->ezplatformConfigFilePath, $config);
+    }
+
+    /**
+     * @Given I :mode configuration to :siteaccessName siteaccess under :keyName key
+     */
+    public function iModifyConfigurationForSiteaccessUnderKey(string $mode, $siteaccessName, $keyName, PyStringNode $configFragment)
+    {
+        $appendToExisting = $this->shouldAppendValue($mode);
+
+        $configurationEditor = new ConfigurationEditor();
+
+        $config = $configurationEditor->getConfigFromFile($this->ezplatformConfigFilePath);
+        $parsedConfig = $this->parseConfig($configFragment);
+        $parentNode = sprintf(self::SITEACCESS_KEY_FORMAT, $siteaccessName, $keyName);
+
+        $config = $appendToExisting ?
+            $configurationEditor->append($config, $parentNode, $parsedConfig) :
+            $configurationEditor->set($config, $parentNode, $parsedConfig);
+        $configurationEditor->saveConfigToFile($this->ezplatformConfigFilePath, $config);
+    }
+
+    private function parseSetting($setting)
+    {
+        return strpos($setting, ',') !== false ? explode(',', $setting) : $setting;
+    }
+
+    private function parseConfig(PyStringNode $configFragment)
+    {
+        $cleanedConfig = '';
+
+        // Remove indent from first line and adjust the rest
+        $firstLine = $configFragment->getStrings()[0];
+        $firstLineIndent = \strlen($firstLine) - \strlen(ltrim($firstLine));
+
+        foreach ($configFragment->getStrings() as $line) {
+            $cleanedConfig = $cleanedConfig . substr($line, $firstLineIndent) . PHP_EOL;
+        }
+
+        return Yaml::parse($cleanedConfig);
+    }
+
+    private function shouldAppendValue(string $value): bool
+    {
+        if (!\in_array($value, ['set', 'append'])) {
+            throw new Exception('Supported modes are: set, append');
+        }
+
+        return 'append' === $value;
+    }
+}

--- a/tests/Core/Configuration/ConfigurationEditorTest.php
+++ b/tests/Core/Configuration/ConfigurationEditorTest.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\Behat\Test;
+
+use EzSystems\Behat\Core\Configuration\ConfigurationEditor;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationEditorTest extends TestCase
+{
+    public function testAppendsValueToConfigWhenKeyDoesNotExistAndConfigIsEmpty()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue');
+
+        Assert::assertEquals(['testKey' => ['testValue']], $config);
+    }
+
+    public function testAppendsValueToConfigWhenKeyDoesNotExistAndConfigIsNotEmpty()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['initialKey' => 'initialValue'];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue');
+
+        Assert::assertEquals(['initialKey' => 'initialValue', 'testKey' => ['testValue']], $config);
+    }
+
+    public function testAppendsValueToConfigWhenCurrentValueIsString()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => 'initialValue'];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue');
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testValue']], $config);
+    }
+
+    public function testAppendsValueToConfigWhenCurrentValueIsArray()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue1', 'initialValue2']];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue');
+
+        Assert::assertEquals(['testKey' => ['initialValue1', 'initialValue2', 'testValue']], $config);
+    }
+
+    public function testAppendsArrayValueToConfigWhenCurrentValueIsString()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => 'initialValue'];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testValue1', 'testValue2']], $config);
+    }
+
+    public function testAppendsArrayValueToConfigWhenCurrentValueIsArray()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue1', 'initialValue2']];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['initialValue1', 'initialValue2', 'testValue1', 'testValue2']], $config);
+    }
+
+    public function testAppendsValueToConfigWhenKeyIsNested()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue']];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey.testSection', 'testValue1');
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1']]], $config);
+    }
+
+    public function testAppendsArrayValueToConfigWhenKeyIsNested()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue']];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey.testSection', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1','testValue2']]], $config);
+    }
+
+    public function testCanAddAnotherValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue1');
+        $config = $configurationEditor->append($config, 'testKey', 'testValue2');
+
+        Assert::assertEquals(['testKey' => ['testValue1','testValue2']], $config);
+    }
+
+    public function testCanAddNestedValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue1');
+        $config = $configurationEditor->append($config, 'testKey.nested', 'testValue2');
+
+        Assert::assertEquals(['testKey' => ['testValue1', 'nested' => ['testValue2']]], $config);
+    }
+
+    public function testCanAddToNestedValue()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->append($initialConfig, 'testKey.nested', 'testValue2');
+        $config = $configurationEditor->append($config, 'testKey', 'testValue1');
+
+        Assert::assertEquals(['testKey' => ['testValue1', 'nested' => ['testValue2']]], $config);
+    }
+
+    public function testSetsValueToConfigWhenKeyDoesNotExistAndConfigIsEmpty()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue']);
+
+        Assert::assertEquals(['testKey' => ['testValue']], $config);
+    }
+
+    public function testSetsValueToConfigWhenKeyDoesNotExistAndConfigIsNotEmpty()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['initialKey' => 'initialValue'];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue']);
+
+        Assert::assertEquals(['initialKey' => 'initialValue', 'testKey' => ['testValue']], $config);
+    }
+
+    public function testSetsValueToConfigWhenCurrentValueIsString()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => 'initialValue'];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue']);
+
+        Assert::assertEquals(['testKey' => ['testValue']], $config);
+    }
+
+    public function testSetsValueToConfigWhenCurrentValueIsArray()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue1', 'initialValue2']];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey','testValue');
+
+        Assert::assertEquals(['testKey' => 'testValue'], $config);
+    }
+
+    public function testSetsArrayValueToConfigWhenCurrentValueIsString()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => 'initialValue'];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['testValue1', 'testValue2']], $config);
+    }
+
+    public function testSetsArrayValueToConfigWhenCurrentValueIsArray()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue1', 'initialValue2']];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['testValue1', 'testValue2']], $config);
+    }
+
+    public function testSetsValueToConfigWhenKeyIsNested()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue']];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey.testSection', 'testValue1');
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => 'testValue1']], $config);
+    }
+
+    public function testSetsArrayValueToConfigWhenKeyIsNested()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['testKey' => ['initialValue']];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey.testSection', ['testValue1', 'testValue2']);
+
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1','testValue2']]], $config);
+    }
+
+    public function testCanSetAnotherValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', 'testValue1');
+        $config = $configurationEditor->set($config, 'testKey', 'testValue2');
+
+        Assert::assertEquals(['testKey' => 'testValue2'], $config);
+    }
+
+    public function testCanSetNestedValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey', ['testValue1']);
+        $config = $configurationEditor->set($config, 'testKey.nested', 'testValue2');
+
+        Assert::assertEquals(['testKey' => ['testValue1', 'nested' => 'testValue2']], $config);
+    }
+
+    public function testCanRemoveNestedValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey.nested', 'testValue2');
+        $config = $configurationEditor->set($config, 'testKey', 'testValue1');
+
+        Assert::assertEquals(['testKey' => 'testValue1'], $config);
+    }
+
+    public function testSetStringValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey.nested', 'testValue2');
+
+        Assert::assertEquals(['testKey' => ['nested' => 'testValue2']], $config);
+    }
+
+    public function testSetIntegerValueWithConfigurationEditor()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = [];
+
+        $config = $configurationEditor->set($initialConfig, 'testKey.nested', 1);
+
+        Assert::assertEquals(['testKey' => ['nested' => 1]], $config);
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30540

This PR adds ability to manage configuration (examples here use ezplatform.yml, but `ConfigurationEditor` will work for any YAML file.

Example after executing added scenarios: https://gist.github.com/mnocon/505dbfaa58e004d09214b6180f2c520e

This does not clear cache (and I don't think it should), meaning that after running the scenarios you need to run `composer run post-install-cmd` manually for the changes to start working.
