### PR TITLE
EZP-30539: Move Platform Behat Bundle to BehatBundle

### DIFF
--- a/src/bundle/BehatExtension.php
+++ b/src/bundle/BehatExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle;
+
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+
+class BehatExtension implements Extension
+{
+    public function getConfigKey()
+    {
+        return 'ezbehatextension';
+    }
+
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $loader = new Loader\YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/Resources/config')
+        );
+        $loader->load('extension.yml');
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+}

--- a/src/bundle/Command/CreateLanguageCommand.php
+++ b/src/bundle/Command/CreateLanguageCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateLanguageCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LanguageService
+     */
+    private $languageService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
+    private $permissionResolver;
+
+    protected function configure()
+    {
+        $this
+            ->setName('ez:behat:create-language')
+            ->setDescription('Create a Language')
+            ->addArgument('language-code', InputArgument::REQUIRED)
+            ->addArgument('language-name', InputArgument::OPTIONAL, 'Language name', '')
+            ->addArgument(
+                'user',
+                InputArgument::OPTIONAL,
+                'eZ Platform User with access to content / translations',
+                'admin'
+            );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        $repository = $this->getContainer()->get('ezpublish.api.repository');
+        $this->languageService = $repository->getContentLanguageService();
+        $this->permissionResolver = $repository->getPermissionResolver();
+        $this->userService = $repository->getUserService();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // set user with proper permissions to create language (content / translations)
+        $this->permissionResolver->setCurrentUserReference(
+            $this->userService->loadUserByLogin(
+                $input->getArgument('user')
+            )
+        );
+
+        $languageCreateStruct = $this->languageService->newLanguageCreateStruct();
+        $languageCreateStruct->languageCode = $input->getArgument('language-code');
+        $languageCreateStruct->name = $input->getArgument('language-name');
+
+        $this->languageService->createLanguage($languageCreateStruct);
+    }
+}

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestSiteaccessCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('ez:behat:siteaccess')
+            ->setDescription('Outputs the name of the active siteaccess');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln($this->getContainer()->get('ezpublish.siteaccess')->name);
+    }
+}

--- a/src/bundle/Controller/ExceptionController.php
+++ b/src/bundle/Controller/ExceptionController.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\Controller;
+
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+
+class ExceptionController
+{
+    public function throwRepositoryUnauthorizedAction($module = 'foo', $function = 'bar', $properties = [])
+    {
+        throw new UnauthorizedException($module, $function, $properties);
+    }
+}

--- a/src/bundle/Resources/config/extension.yml
+++ b/src/bundle/Resources/config/extension.yml
@@ -1,0 +1,6 @@
+services:
+
+    ezbehatbundle.core.behat.context_argument_resolver:
+        class: EzSystems\Behat\Core\Behat\AnnotationArgumentResolver
+        tags:
+            -  { name: context.argument_resolver, priority: 100 }

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+ez_platform_behat_repository_unauthorized_exception:
+    path: '/platform-behat/exceptions/repository-unauthorized'
+    defaults:
+        _controller: 'ezbehatbundle.controller.exception:throwRepositoryUnauthorizedAction'

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -27,3 +27,6 @@ services:
 
     ezbehatbundle.api.facade.languagefacade:
         class: EzSystems\Behat\API\Facade\LanguageFacade
+
+    ezbehatbundle.controller.exception:
+        class: EzSystems\BehatBundle\Controller\ExceptionController

--- a/src/bundle/Resources/views/tests/dump.html.twig
+++ b/src/bundle/Resources/views/tests/dump.html.twig
@@ -1,0 +1,5 @@
+<h1>Dump</h1>
+
+<p>Result of <pre style="display: inline">dump()</pre>:</p>
+
+{{ dump() }}

--- a/src/lib/Core/Behat/AnnotationArgumentResolver.php
+++ b/src/lib/Core/Behat/AnnotationArgumentResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Behat;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+use ReflectionClass;
+
+/**
+ * Behat Context Argument Resolver.
+ */
+class AnnotationArgumentResolver implements ArgumentResolver
+{
+    /**
+     * Service annotation tag.
+     */
+    const SERVICE_DOC_TAG = 'injectService';
+
+    /**
+     * Resolve service arguments for Behat Context constructor thru annotation.
+     * Symfony2Extension ArgumentResoler will convert service names to actual instances.
+     *
+     * @param ReflectionClass $classReflection
+     * @param array $arguments
+     */
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments = [])
+    {
+        $injArguments = $this->parseAnnotations(
+            $this->getMethodAnnotations($classReflection)
+        );
+
+        if (!empty($injArguments)) {
+            $arguments = [];
+            foreach ($injArguments as $name => $service) {
+                $arguments[$name] = $service;
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Returns a array with the method annotations.
+     *
+     * @return array array annotations
+     */
+    private function getMethodAnnotations($refClass, $method = '__construct')
+    {
+        if ($refClass->hasMethod($method)) {
+            $refMethod = $refClass->getMethod($method);
+            preg_match_all('#@(.*?)\n#s', $refMethod->getDocComment(), $matches);
+
+            return $matches[1];
+        } else {
+            return [];
+        }
+    }
+
+    /**
+     * Returns an array with the method arguments service requirements,
+     * if the methods use the service Annotation.
+     *
+     * @return array array of methods and their service dependencies
+     */
+    private function parseAnnotations($annotations)
+    {
+        // parse array from (numeric key => 'annotation <value>') to (annotation => value)
+        $methodServices = [];
+        foreach ($annotations as $annotation) {
+            if (!preg_match('/^(\w+)\s+\$(\w+)\s+([\w\.\@\%]+)/', $annotation, $matches)) {
+                continue;
+            }
+
+            array_shift($matches);
+            $tag = array_shift($matches);
+            if ($tag == self::SERVICE_DOC_TAG) {
+                list($argument, $service) = $matches;
+                $methodServices[$argument] = $service;
+            }
+        }
+
+        return $methodServices;
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30539

This PR adds parts of PlatformBehatBundle from https://github.com/ezsystems/ezpublish-kernel/pull/2642

Things ported:
- Behat extension. It's useful, though if we will be able to switch to Symfony4Extension we will be able to drop it as well
- Controller, Twig template, Commands  - it's a good start to have these things here and slowly grow the base of real examples how to customise the product (and test the behaviour by the way)

Removed:
- Deprecation suppression - I believe it's better to handle each deprecation separately, not with a general "suppress all" tool (also it turned out it wasn't needed)
- RepositoryContext trait - this is achieved with TestContext now