### PR TITLE
EZP-30668: move core tests classes from AdminUI to BehatBundle

### DIFF
--- a/src/lib/API/ContentData/FieldTypeNameConverter.php
+++ b/src/lib/API/ContentData/FieldTypeNameConverter.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\API\ContentData;
+
+class FieldTypeNameConverter
+{
+    private static $FIELD_TYPE_MAPPING = [
+        'ezauthor' => 'Authors',
+        'ezboolean' => 'Checkbox',
+        'ezobjectrelation' => 'Content relation (single)',
+        'ezobjectrelationlist' => 'Content relations (multiple)',
+        'ezcountry' => 'Country',
+        'ezdate' => 'Date',
+        'ezdatetime' => 'Date and time',
+        'ezemail' => 'Email address',
+        'ezbinaryfile' => 'File',
+        'ezfloat' => 'Float',
+        'ezisbn' => 'ISBN',
+        'ezimage' => 'Image',
+        'ezinteger' => 'Integer',
+        'ezkeyword' => 'Keywords',
+        'ezlandingpage' => 'Landing Page',
+        'ezpage' => 'Layout',
+        'ezgmaplocation' => 'Map location',
+        'ezmedia' => 'Media',
+        'ezsrrating' => 'Rating',
+        'ezrichtext' => 'Rich text',
+        'ezselection' => 'Selection',
+        'eztext' => 'Text block',
+        'ezstring' => 'Text line',
+        'eztime' => 'Time',
+        'ezurl' => 'URL',
+        'ezuser' => 'User account',
+    ];
+
+    public static function getFieldTypeNameByIdentifier(string $fieldTypeIdentifier): string
+    {
+        return static::$FIELD_TYPE_MAPPING[$fieldTypeIdentifier];
+    }
+
+    public static function getFieldTypeIdentifierByName(string $fieldTypeName): string
+    {
+        return array_search($fieldTypeName, static::$FIELD_TYPE_MAPPING);
+    }
+}

--- a/src/lib/Browser/Context/BrowserContext.php
+++ b/src/lib/Browser/Context/BrowserContext.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Context;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\MinkExtension\Context\MinkContext;
+use Exception;
+use WebDriver\Exception\ElementNotVisible;
+
+class BrowserContext extends MinkContext
+{
+    /**
+     * Waits until element is visible. If it does not appear throws exception.
+     *
+     * @param string $cssSelector
+     * @param int $timeout
+     *
+     * @throws Exception when element not found or is not visible
+     */
+    public function waitUntilElementIsVisible(string $cssSelector, int $timeout = 5, TraversableElement $baseElement = null): void
+    {
+        try {
+            $this->waitUntil($timeout, function () use ($cssSelector, $baseElement) {
+                $baseElement = $baseElement ?? $this->getSession()->getPage();
+
+                $element = $baseElement->find('css', $cssSelector);
+
+                return isset($element) && $element->isVisible();
+            });
+        } catch (Exception $e) {
+            throw new ElementNotVisible(sprintf('Element with selector: %s was not found', $cssSelector));
+        }
+    }
+
+    /**
+     * Adpted Mink find function combined with a spin function
+     * to find all element with a given css selector that might still be loading.
+     *
+     * @param   string      $locator        css selector for the element
+     * @param   TraversableElement|null $baseElement    base Mink node element from where the find should be called
+     *
+     * @return  NodeElement[]
+     */
+    public function findAllElements(string $locator, TraversableElement $baseElement = null): array
+    {
+        $baseElement = $baseElement ?? $this->getSession()->getPage();
+
+        $elements = $this->waitUntil(10,
+            function () use ($locator, $baseElement) {
+                $elements = $baseElement->findAll('css', $locator);
+                foreach ($elements as $element) {
+                    // An exception may be thrown if the element is not valid/attached to DOM.
+                    $element->getValue();
+                }
+
+                return $elements;
+            }
+        );
+
+        return $elements;
+    }
+
+    /**
+     * Finds an HTML element by class and the text value and returns it. Search can be narrowed to children of baseElement.
+     *
+     * @param string $text Text value of the element
+     * @param string $selector CSS selector of the element
+     * @param string $textSelector Extra CSS selector for text of the element
+     * @param TraversableElement|null $baseElement
+     *
+     * @return NodeElement|null
+     */
+    public function getElementByText(string $text, string $selector, string $textSelector = null, TraversableElement $baseElement = null): ?NodeElement
+    {
+        $baseElement = $baseElement ?? $this->getSession()->getPage();
+
+        $elements = $this->findAllElements($selector, $baseElement);
+        foreach ($elements as $element) {
+            if ($textSelector !== null) {
+                try {
+                    $elementText = $this->findElement($textSelector, 10, $element)->getText();
+                } catch (\Exception $e) {
+                    continue;
+                }
+            } else {
+                $elementText = $element->getText();
+            }
+            if ($elementText === $text) {
+                return $element;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds an HTML element by class and the fragment of text value and returns it. Search can be narrowed to children of baseElement.
+     *
+     * @param string $text Fragment of text value of the element
+     * @param string $selector CSS selector of the element
+     * @param string $textSelector Extra CSS selector for text of the element
+     * @param TraversableElement|null $baseElement
+     *
+     * @return NodeElement|null
+     */
+    public function getElementByTextFragment(string $textFragment, string $selector, string $textSelector = null, TraversableElement $baseElement = null): ?NodeElement
+    {
+        $baseElement = $baseElement ?? $this->getSession()->getPage();
+
+        $elements = $this->findAllElements($selector, $baseElement);
+        foreach ($elements as $element) {
+            if ($textSelector !== null) {
+                try {
+                    $elementText = $this->findElement($textSelector, 10, $element)->getText();
+                } catch (\Exception $e) {
+                    continue;
+                }
+            } else {
+                $elementText = $element->getText();
+            }
+            if (strpos($elementText, $textFragment) !== false) {
+                return $element;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds an HTML element by class and the text value and returns it's position in order. Search can be narrowed to children of baseElement.
+     *
+     * @param string $text Text value of the element
+     * @param string $selector CSS selector of the element
+     * @param string $textSelector Extra CSS selector for text of the element
+     * @param TraversableElement|null $baseElement
+     *
+     * @return int
+     */
+    public function getElementPositionByText(string $text, string $selector, string $textSelector = null, TraversableElement $baseElement = null): int
+    {
+        $baseElement = $baseElement ?? $this->getSession()->getPage();
+        $counter = 0;
+
+        $elements = $this->findAllElements($selector, $baseElement);
+        foreach ($elements as $element) {
+            ++$counter;
+            if ($textSelector !== null) {
+                try {
+                    $elementText = $this->findElement($textSelector, 10, $element)->getText();
+                } catch (\Exception $e) {
+                    continue;
+                }
+            } else {
+                $elementText = $element->getText();
+            }
+            if ($elementText === $text) {
+                return $counter;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Waits no longer than specified timeout for the given condition to be true.
+     *
+     * @param int $timeoutSeconds Timeout
+     * @param callable Condition to verify
+     * @param bool $throwOnFailure Whether Exception should be thrown when timeout is exceeded
+     *
+     * @return mixed
+     *
+     * @throws Exception If $throwOnFailure is true and timeout exceeded
+     */
+    public function waitUntil(int $timeoutSeconds, callable $callback, bool $throwOnFailure = true)
+    {
+        if (!\is_callable($callback)) {
+            throw new \InvalidArgumentException('Given callback is not a valid callable');
+        }
+
+        $start = time();
+        $end = $start + $timeoutSeconds;
+
+        $lastInternalExceptionMessage = '';
+
+        do {
+            try {
+                $result = $callback($this);
+
+                if ($result) {
+                    return $result;
+                }
+            } catch (Exception $e) {
+                $lastInternalExceptionMessage = $e->getMessage();
+            }
+            usleep(250 * 1000);
+        } while (time() < $end);
+
+        if ($throwOnFailure) {
+            throw new Exception('Spin function did not return in time. Last internal exception:' . $lastInternalExceptionMessage);
+        }
+    }
+
+    /**
+     * Adopted Mink find function to find one element that might still be loading.
+     *
+     * @param string $selector CSS selector for the element
+     * @param int $timeout
+     * @param TraversableElement|null $baseElement Element from which the DOM will be searched
+     *
+     * @return NodeElement Searched element
+     *
+     * @throws ElementNotFoundException
+     */
+    public function findElement(string $selector, int $timeout = 5, TraversableElement $baseElement = null): NodeElement
+    {
+        $baseElement = $baseElement ?? $this->getSession()->getPage();
+
+        try {
+            return $this->waitUntil($timeout,
+                function () use ($selector, $baseElement) {
+                    return $baseElement->find('css', $selector);
+                });
+        } catch (Exception $e) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), null, 'css', $selector);
+        }
+    }
+
+    /**
+     * Filters an array of elements and returns the visible ones.
+     *
+     * @param NodeElement[] $elements
+     *
+     * @return NodeElement[]
+     */
+    public function getVisibleElements(array $elements): array
+    {
+        return array_filter($elements, function ($element) { return $element->isVisible(); });
+    }
+
+    /**
+     * Checks the visibility of a HTML element found by class.
+     *
+     * @param string $locator CSS locator of the element
+     * @param int $timeout Number of seconds to wait until the element appears
+     *
+     * @return bool
+     */
+    public function isElementVisible(string $locator, int $timeout = 5): bool
+    {
+        try {
+            $element = $this->findElement($locator, $timeout);
+
+            return isset($element) && $element->isVisible();
+        } catch (ElementNotFoundException $e) {
+            return false;
+        }
+    }
+
+    public function waitUntilElementDisappears(string $cssSelector, int $timeout): void
+    {
+        try {
+            $this->waitUntil($timeout, function () use ($cssSelector, $timeout) {
+                return !$this->isElementVisible($cssSelector, 1);
+            });
+        } catch (Exception $e) {
+            throw new Exception(sprintf('Element with selector: %s did not disappear in %d seconds.', $cssSelector, $timeout));
+        }
+    }
+
+    /**
+     * Uploads file from location stored in 'files_path' to the disc on remote browser machine. Mink require uploaded file to be zip archive.
+     *
+     * @param string $localFileName
+     *
+     * @return string
+     */
+    public function uploadFileToRemoteSpace(string $localFileName): string
+    {
+        if (!preg_match('#[\w\\\/\.]*\.zip$#', $localFileName)) {
+            throw new \InvalidArgumentException('Zip archive required to upload to remote browser machine.');
+        }
+
+        $localFile = sprintf('%s%s', $this->getMinkParameter('files_path'), $localFileName);
+
+        return $this->getSession()->getDriver()->getWebDriverSession()->file([
+            'file' => base64_encode(file_get_contents($localFile)),
+        ]);
+    }
+
+    private function isDraggingLibraryLoaded(): bool
+    {
+        return $this->getSession()->getDriver()->evaluateScript("typeof(dragMock) !== 'undefined'");
+    }
+
+    public function moveWithHover(string $startExpression, string $hoverExpression, string $placeholderExpression): void
+    {
+        $this->loadDraggingLibrary();
+
+        $movingScript = sprintf('dragMock.dragStart(%s).dragOver(%s).delay(100).drop(%s);', $startExpression, $hoverExpression, $placeholderExpression);
+        $this->getSession()->getDriver()->executeScript($movingScript);
+    }
+
+    private function loadDraggingLibrary(): void
+    {
+        if ($this->isDraggingLibraryLoaded()) {
+            return;
+        }
+
+        $script = file_get_contents(__DIR__ . '/../lib/drag-mock.js');
+        $this->getSession()->getDriver()->executeScript($script);
+        $this->waitUntil(10, function () {
+            return $this->isDraggingLibraryLoaded();
+        });
+    }
+}

--- a/src/lib/Browser/Context/Hooks.php
+++ b/src/lib/Browser/Context/Hooks.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Context;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Symfony2Extension\Context\KernelDictionary;
+use Behat\Testwork\Tester\Result\TestResult;
+use EzSystems\Behat\Browser\Filter\BrowserLogFilter;
+use EzSystems\Behat\Browser\Factory\ElementFactory;
+use EzSystems\Behat\Browser\Factory\PageObjectFactory;
+use EzSystems\Behat\Core\Environment\Environment;
+use EzSystems\Behat\Core\Environment\EnvironmentConstants;
+use WebDriver\LogType;
+use Behat\MinkExtension\Context\RawMinkContext;
+
+class Hooks extends RawMinkContext
+{
+    private const CONSOLE_LOGS_LIMIT = 10;
+    private const APPLICATION_LOGS_LIMIT = 10;
+    private const LOG_FILE_NAME = 'travis_test.log';
+
+    use KernelDictionary;
+
+    /** @BeforeScenario
+     */
+    public function setInstallTypeBeforeScenario()
+    {
+        $env = new Environment($this->getContainer());
+        $installType = $env->getInstallType();
+
+        PageObjectFactory::setInstallType($installType);
+        ElementFactory::setInstallType($installType);
+        EnvironmentConstants::setInstallType($installType);
+    }
+
+    /** @AfterStep */
+    public function getLogsAfterFailedStep(AfterStepScope $scope)
+    {
+        if ($scope->getTestResult()->getResultCode() !== TestResult::FAILED) {
+            return;
+        }
+
+        $driver = $this->getSession()->getDriver();
+        if ($driver instanceof Selenium2Driver) {
+            $browserLogEntries = $this->parseBrowserLogs($driver->getWebDriverSession()->log(LogType::BROWSER));
+            $this->displayLogEntries('JS console errors:', $browserLogEntries);
+        }
+
+        $applicationLogEntries = $this->parseApplicationlogs();
+        $this->displayLogEntries('Application errors:', $applicationLogEntries);
+    }
+
+    private function parseApplicationlogs(): array
+    {
+        $logEntries = [];
+        $counter = 0;
+
+        $file = @fopen(sprintf('%s/%s', $this->getKernel()->getLogDir(), self::LOG_FILE_NAME), 'r');
+
+        if ($file === false) {
+            return $logEntries;
+        }
+
+        while (!feof($file)) {
+            if ($counter >= self::APPLICATION_LOGS_LIMIT) {
+                break;
+            }
+
+            $logEntries[] = fgets($file);
+            ++$counter;
+        }
+
+        fclose($file);
+
+        return $logEntries;
+    }
+
+    private function parseBrowserLogs($logEntries): array
+    {
+        if (empty($logEntries)) {
+            return [];
+        }
+
+        $filter = new BrowserLogFilter();
+        $errorMessages = array_column($logEntries, 'message');
+        $errorMessages = $filter->filter($errorMessages);
+
+        return \array_slice($errorMessages, 0, self::CONSOLE_LOGS_LIMIT);
+    }
+
+    private function displayLogEntries($sectionName, $logEntries)
+    {
+        if (empty($logEntries)) {
+            return;
+        }
+
+        echo sprintf('%s' . PHP_EOL, $sectionName);
+
+        foreach ($logEntries as $logEntry) {
+            echo sprintf('%s' . PHP_EOL, $logEntry);
+        }
+    }
+}

--- a/src/lib/Browser/Element/Element.php
+++ b/src/lib/Browser/Element/Element.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Element;
+
+use EzSystems\Behat\Browser\Context\BrowserContext;
+
+/** Abstract for pages elements */
+abstract class Element
+{
+    /** @var int */
+    public $defaultTimeout = 5;
+
+    /* @var \EzSystems\Behat\Browser\Context\BrowserContext */
+    protected $context;
+
+    protected $fields;
+
+    public function __construct(BrowserContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function verifyVisibility(): void
+    {
+    }
+}

--- a/src/lib/Browser/Factory/ElementFactory.php
+++ b/src/lib/Browser/Factory/ElementFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Factory;
+
+use EzSystems\Behat\Browser\Context\BrowserContext;
+use EzSystems\Behat\Core\Environment\InstallType;
+use EzSystems\EzPlatformAdminUi\Behat\PageElement\PlatformElementFactory;
+use EzSystems\EzPlatformPageBuilder\Tests\Behat\PageElement\EnterpriseElementFactory;
+use Tests\AppBundle\Behat\PageElement\DemoEnterpriseElementFactory;
+
+class ElementFactory
+{
+    private static $installType;
+
+    private static $factory;
+
+    /**
+     * Creates a Element object based on given Element Name.
+     *
+     * @param UtilityContext $context
+     * @param string $elementName Name of the Element to creator
+     */
+    public static function createElement(BrowserContext $context, string $elementName, ?string ...$parameters)
+    {
+        /* Note: no return type to enable type-hinting */
+
+        if (self::$factory === null) {
+            self::$factory = self::getFactory(self::$installType);
+        }
+
+        return self::$factory::createElement($context, $elementName, ...$parameters);
+    }
+
+    public static function setInstallType(int $installType)
+    {
+        self::$installType = $installType;
+    }
+
+    public static function getPreviewType(string $contentType)
+    {
+        /* Note: no return type to enable type-hinting */
+
+        if (self::$factory === null) {
+            self::$factory = self::getFactory(self::$installType);
+        }
+
+        return self::$factory::getPreviewType($contentType);
+    }
+
+    /**
+     * @param int $installType
+     *
+     * @return EnterpriseElementFactory|PlatformElementFactory
+     */
+    private static function getFactory(int $installType): PlatformElementFactory
+    {
+        switch ($installType) {
+            case InstallType::PLATFORM:
+            case InstallType::PLATFORM_DEMO:
+                return new PlatformElementFactory();
+            case InstallType::ENTERPRISE:
+                return new EnterpriseElementFactory();
+            case InstallType::ENTERPRISE_DEMO:
+                return new DemoEnterpriseElementFactory();
+            default:
+                throw new \Exception('Unrecognised install type');
+        }
+    }
+}

--- a/src/lib/Browser/Factory/PageObjectFactory.php
+++ b/src/lib/Browser/Factory/PageObjectFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Factory;
+
+use EzSystems\Behat\Browser\Context\BrowserContext;
+use EzSystems\Behat\Core\Environment\InstallType;
+use EzSystems\EzPlatformAdminUi\Behat\PageObject\PlatformPageObjectFactory;
+use EzSystems\EzPlatformPageBuilder\Tests\Behat\PageObject\EnterprisePageObjectFactory;
+use Tests\AppBundle\Behat\PageObject\DemoEnterprisePageObjectFactory;
+
+class PageObjectFactory
+{
+    private static $installType;
+
+    private static $factory;
+
+    /**
+     * Creates a Page object based on given Page Name.
+     *
+     * @param UtilityContext $context
+     * @param string $pageName Name of the Page to creator
+     * @param null[]|string[] $parameters additional parameters
+     */
+    public static function createPage(BrowserContext $context, string $pageName, ?string ...$parameters)
+    {
+        /* Note: no return type to enable type-hinting */
+
+        if (self::$factory === null) {
+            self::$factory = self::getFactory(self::$installType);
+        }
+
+        return self::$factory::createPage($context, $pageName, ...$parameters);
+    }
+
+    public static function setInstallType(int $installType)
+    {
+        self::$installType = $installType;
+    }
+
+    public static function getPreviewType(string $contentType)
+    {
+        /* Note: no return type to enable type-hinting */
+        $factory = self::getFactory(self::$installType);
+
+        return $factory::getPreviewType($contentType);
+    }
+
+    /**
+     * @param int $installType
+     *
+     * @throws \Exception
+     */
+    private static function getFactory(int $installType)
+    {
+        switch ($installType) {
+            case InstallType::PLATFORM:
+            case InstallType::PLATFORM_DEMO:
+                return new PlatformPageObjectFactory();
+            case InstallType::ENTERPRISE:
+                return new EnterprisePageObjectFactory();
+            case InstallType::ENTERPRISE_DEMO:
+                return new DemoEnterprisePageObjectFactory();
+            default:
+                throw new \Exception('Unrecognised install type');
+        }
+    }
+}

--- a/src/lib/Browser/Filter/BrowserLogFilter.php
+++ b/src/lib/Browser/Filter/BrowserLogFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Filter;
+
+class BrowserLogFilter
+{
+    private $excludedPatterns = [
+        '@.*/api/ezp/v2/bookmark/.* - Failed to load resource: the server responded with a status of 404 \(Not Found\)@',
+        '@.*/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.@',
+        '@.*/admin/version-draft/has-no-conflict/.* - Failed to load resource: the server responded with a status of 409 \(Conflict\)@',
+        '@webpack:///./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js\? 91:12 "EzObjectRelation fieldtype is deprecated. Please, use EzObjectRelationList fieldtype instead."@',
+    ];
+
+    public function filter(array $logEntries): array
+    {
+        return array_values(array_filter($logEntries, function ($logEntry) {
+            foreach ($this->excludedPatterns as $excludedPattern) {
+                if (preg_match($excludedPattern, $logEntry)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+}

--- a/src/lib/Browser/Page/Page.php
+++ b/src/lib/Browser/Page/Page.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Page;
+
+use EzSystems\Behat\Browser\Context\BrowserContext;
+use PHPUnit\Framework\Assert;
+
+abstract class Page
+{
+    protected $defaultTimeout = 50;
+
+    /** @var string Route under which the Page is available */
+    protected $route;
+
+    /** @var string title that we see directly below upper menu */
+    protected $pageTitle;
+
+    /** @var BrowserContext context for interactions with the page */
+    protected $context;
+
+    /** @var string locator for page title */
+    protected $pageTitleLocator;
+
+    // @var UpperMenu
+    public $upperMenu;
+
+    public function __construct(BrowserContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Makes sure that the page is loaded.
+     */
+    public function verifyIsLoaded(): void
+    {
+        $this->verifyRoute();
+        $this->verifyElements();
+        $this->verifyTitle();
+    }
+
+    /**
+     * Opens the page in Browser.
+     *
+     * @param bool $verifyIfLoaded Page content will be verified
+     */
+    public function open(bool $verifyIfLoaded = true): void
+    {
+        $this->context->visit($this->route);
+
+        if ($verifyIfLoaded) {
+            $this->verifyIsLoaded();
+        }
+    }
+
+    /**
+     * Verifies that Page is available under correct route.
+     */
+    public function verifyRoute(): void
+    {
+        $this->context->waitUntil($this->defaultTimeout, function () {
+            return false !== strpos($this->context->getSession()->getCurrentUrl(), $this->route);
+        });
+    }
+
+    public function verifyTitle(): void
+    {
+        Assert::assertEquals(
+            $this->pageTitle,
+            $this->getPageTitle(),
+            'Wrong page title.'
+        );
+    }
+
+    /**
+     * Verifies that expected elements are present.
+     */
+    abstract public function verifyElements(): void;
+
+    /**
+     * Gets the header text displayed in AdminUI.
+     *
+     * @return string
+     */
+    public function getPageTitle(): string
+    {
+        return $this->context->findElement($this->pageTitleLocator)->getText();
+    }
+}

--- a/src/lib/Browser/Page/Preview/FolderPreview.php
+++ b/src/lib/Browser/Page/Preview/FolderPreview.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Page\Preview;
+
+class FolderPreview extends PreviewPage
+{
+    /** @var string Name by which Page is recognised */
+    public const PAGE_NAME = 'Folder Preview';
+
+    /** @var string Name of Content Type this Preview is for */
+    public const CONTENT_TYPE = 'Folder';
+
+    public function getPageTitle(): string
+    {
+        return $this->context->findElement('h2')->getText();
+    }
+
+    public function verifyElements(): void
+    {
+    }
+
+    public function getDefaultPreviewData(): ?array
+    {
+        return null;
+    }
+}

--- a/src/lib/Browser/Page/Preview/PreviewPage.php
+++ b/src/lib/Browser/Page/Preview/PreviewPage.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Browser\Page\Preview;
+
+use EzSystems\Behat\Browser\Page\Page;
+
+abstract class PreviewPage extends Page
+{
+    public function setTitle(string $title): void
+    {
+        $this->pageTitle = $title;
+    }
+
+    abstract public function getDefaultPreviewData(): ?array;
+}

--- a/src/lib/Browser/lib/drag-mock.js
+++ b/src/lib/Browser/lib/drag-mock.js
@@ -1,0 +1,30 @@
+/* drag-mock library
+https://github.com/andywer/drag-mock
+version 1.4.0
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Andy Wermke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+
+!function t(e,n,r){function a(i,u){if(!n[i]){if(!e[i]){var s="function"==typeof require&&require;if(!u&&s)return s(i,!0);if(o)return o(i,!0);var c=new Error("Cannot find module '"+i+"'");throw c.code="MODULE_NOT_FOUND",c}var f=n[i]={exports:{}};e[i][0].call(f.exports,function(t){var n=e[i][1][t];return a(n?n:t)},f,f.exports,t,e,n,r)}return n[i].exports}for(var o="function"==typeof require&&require,i=0;i<r.length;i++)a(r[i]);return a}({1:[function(t){var e=t("./src/index.js");"function"==typeof define&&define("dragMock",function(){return e}),window.dragMock=e},{"./src/index.js":5}],2:[function(t,e){function n(t,e){var n=t.indexOf(e);n>=0&&t.splice(n,1)}var r=function(){this.dataByFormat={},this.dropEffect="none",this.effectAllowed="all",this.files=[],this.types=[]};r.prototype.clearData=function(t){t?(delete this.dataByFormat[t],n(this.types,t)):(this.dataByFormat={},this.types=[])},r.prototype.getData=function(t){return this.dataByFormat[t]},r.prototype.setData=function(t,e){return this.dataByFormat[t]=e,this.types.indexOf(t)<0&&this.types.push(t),!0},r.prototype.setDragImage=function(){},e.exports=r},{}],3:[function(t,e){function n(){}function r(t,e,r){if("function"==typeof e&&(r=e,e=null),!t||"object"!=typeof t)throw new Error("Expected first parameter to be a targetElement. Instead got: "+t);return{targetElement:t,eventProperties:e||{},configCallback:r||n}}function a(t,e,n){e&&(e.length<2?n&&e(t):e(t,t.type))}function o(t,e,n,r,o,u){e.forEach(function(e){var s=i.createEvent(e,o,r),c=e===n;a(s,u,c),t.dispatchEvent(s)})}var i=t("./eventFactory"),u=t("./DataTransfer"),s=function(){this.lastDragSource=null,this.lastDataTransfer=null,this.pendingActionsQueue=[]};s.prototype._queue=function(t){this.pendingActionsQueue.push(t),1===this.pendingActionsQueue.length&&this._queueExecuteNext()},s.prototype._queueExecuteNext=function(){if(0!==this.pendingActionsQueue.length){var t=this,e=this.pendingActionsQueue[0],n=function(){t.pendingActionsQueue.shift(),t._queueExecuteNext()};0===e.length?(e.call(this),n()):e.call(this,n)}},s.prototype.dragStart=function(t,e,n){var a=r(t,e,n),i=["mousedown","dragstart","drag"],s=new u;return this._queue(function(){o(a.targetElement,i,"drag",s,a.eventProperties,a.configCallback),this.lastDragSource=t,this.lastDataTransfer=s}),this},s.prototype.dragOver=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseover","dragover"];return this._queue(function(){o(a.targetElement,i,"drag",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.dragLeave=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseover","dragleave"];return this._queue(function(){o(a.targetElement,i,"dragleave",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.drop=function(t,e,n){var a=r(t,e,n),i=["mousemove","mouseup","drop"],u=["dragend"];return this._queue(function(){o(a.targetElement,i,"drop",this.lastDataTransfer,a.eventProperties,a.configCallback),this.lastDragSource&&o(this.lastDragSource,u,"drop",this.lastDataTransfer,a.eventProperties,a.configCallback)}),this},s.prototype.then=function(t){return this._queue(function(){t.call(this)}),this},s.prototype.delay=function(t){return this._queue(function(e){window.setTimeout(e,t)}),this},e.exports=s},{"./DataTransfer":2,"./eventFactory":4}],4:[function(t,e){function n(t,e){for(var n in e)e.hasOwnProperty(n)&&(t[n]=e[n]);return t}function r(t,e,r){"DragEvent"===e&&(e="CustomEvent");var a=window[e],o={view:window,bubbles:!0,cancelable:!0};n(o,r);var i=new a(t,o);return n(i,r),i}function a(t,e,r){var a;switch(e){case"MouseEvent":a=document.createEvent("MouseEvent"),a.initEvent(t,!0,!0);break;default:a=document.createEvent("CustomEvent"),a.initCustomEvent(t,!0,!0,0)}return r&&n(a,r),a}function o(t,e,n){try{return r(t,e,n)}catch(o){return a(t,e,n)}}var i=t("./DataTransfer"),u=["drag","dragstart","dragover","dragend","drop","dragleave"],s={createEvent:function(t,e,n){var r="CustomEvent";t.match(/^mouse/)&&(r="MouseEvent");var a=o(t,r,e);return u.indexOf(t)>-1&&(a.dataTransfer=n||new i),a}};e.exports=s},{"./DataTransfer":2}],5:[function(t,e){function n(t,e,n){return t[e].apply(t,n)}var r=t("./DragDropAction"),a={dragStart:function(){return n(new r,"dragStart",arguments)},dragOver:function(){return n(new r,"dragOver",arguments)},dragLeave:function(){return n(new r,"dragLeave",arguments)},drop:function(){return n(new r,"drop",arguments)},delay:function(){return n(new r,"delay",arguments)},DataTransfer:t("./DataTransfer"),DragDropAction:t("./DragDropAction"),eventFactory:t("./eventFactory")};e.exports=a},{"./DataTransfer":2,"./DragDropAction":3,"./eventFactory":4}]},{},[1]);

--- a/src/lib/Core/Behat/TableNodeExtension.php
+++ b/src/lib/Core/Behat/TableNodeExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Behat;
+
+use Behat\Gherkin\Node\TableNode;
+
+class TableNodeExtension extends TableNode
+{
+    /**
+     * Adds a column (in form: ['header' => [values]] or ['header' => 'value']) to a given table.
+     *
+     * @param TableNode $table
+     * @param array $columnData
+     *
+     * @return TableNode
+     *
+     * @throws \Behat\Gherkin\Exception\NodeException
+     */
+    public static function addColumn(TableNode $table, array $columnData): TableNode
+    {
+        $headers = array_keys($columnData);
+
+        $newParameters = $table->getTable();
+
+        foreach ($headers as $header) {
+            $row = array_keys($table->getTable())[0];
+            $newParameters[$row++][] = $header;
+            if (\is_array($columnData[$header])) {
+                foreach ($columnData[$header] as $value) {
+                    $newParameters[$row++][] = $value;
+                }
+            } else {
+                $newParameters[$row][] = $columnData[$header];
+            }
+        }
+
+        return new self($newParameters);
+    }
+}

--- a/src/lib/Core/Environment/Environment.php
+++ b/src/lib/Core/Environment/Environment.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Environment;
+
+use EzSystems\PlatformInstallerBundle\Installer\Installer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Environment
+{
+    /** @var \Symfony\Component\DependencyInjection\ContainerInterface Symfony DI service container */
+    private $serviceContainer;
+
+    /** @var array Names of available installer services in Studio */
+    private $installerServices = ['platform' => 'ezplatform.installer.clean_installer',
+        'platform-demo' => 'app.installer.demo_installer',
+        'platform-ee' => 'ezstudio.installer.studio_installer',
+        'platform-ee-demo' => 'app.installer.ee-demo_installer', ];
+
+    /**
+     * Environment constructor.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $serviceContainer
+     */
+    public function __construct(ContainerInterface $serviceContainer)
+    {
+        $this->serviceContainer = $serviceContainer;
+    }
+
+    public function getInstallType(): int
+    {
+        if ($this->serviceContainer->has($this->installerServices['platform-ee-demo'])) {
+            return InstallType::ENTERPRISE_DEMO;
+        }
+
+        if ($this->serviceContainer->has($this->installerServices['platform-ee'])) {
+            return InstallType::ENTERPRISE;
+        }
+
+        if ($this->serviceContainer->has($this->installerServices['platform-demo'])) {
+            return InstallType::PLATFORM_DEMO;
+        }
+
+        if ($this->serviceContainer->has($this->installerServices['platform'])) {
+            return InstallType::PLATFORM;
+        }
+    }
+}

--- a/src/lib/Core/Environment/EnvironmentConstants.php
+++ b/src/lib/Core/Environment/EnvironmentConstants.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Environment;
+
+use EzSystems\EzPlatformAdminUi\Behat\Environment\PlatformEnvironmentConstants;
+use EzSystems\EzPlatformPageBuilder\Tests\Behat\Environment\EnterpriseEnvironmentConstants;
+use Tests\AppBundle\Behat\PlatformDemoEnvironmentConstants;
+use Tests\AppBundle\Behat\EnterpriseDemoEnvironmentConstants;
+
+class EnvironmentConstants
+{
+    private static $installType;
+
+    public static function setInstallType(int $installType)
+    {
+        self::$installType = $installType;
+    }
+
+    public static function get(string $key): string
+    {
+        $env = self::getProperEnvironment(self::$installType);
+
+        return $env->values[$key];
+    }
+
+    public static function getInstallType(): string
+    {
+        return self::$installType;
+    }
+
+    private static function getProperEnvironment(int $installType)
+    {
+        switch ($installType) {
+            case InstallType::PLATFORM:
+                return new PlatformEnvironmentConstants();
+            case InstallType::PLATFORM_DEMO:
+                return new PlatformDemoEnvironmentConstants();
+            case InstallType::ENTERPRISE:
+                return new EnterpriseEnvironmentConstants();
+            case InstallType::ENTERPRISE_DEMO:
+                return new EnterpriseDemoEnvironmentConstants();
+            default:
+                throw new \Exception('Unrecognised install type');
+        }
+    }
+}

--- a/src/lib/Core/Environment/InstallType.php
+++ b/src/lib/Core/Environment/InstallType.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Environment;
+
+abstract class InstallType
+{
+    public const PLATFORM = 1;
+    public const PLATFORM_DEMO = 2;
+    public const ENTERPRISE = 3;
+    public const ENTERPRISE_DEMO = 4;
+}

--- a/tests/Browser/Filter/BrowserLogFilterTest.php
+++ b/tests/Browser/Filter/BrowserLogFilterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Test\Browser\Filter;
+
+use EzSystems\Behat\Browser\Filter\BrowserLogFilter;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class BrowserLogFilterTest extends TestCase
+{
+    public function testFiltersOutExcludedPatterns()
+    {
+        $initialLogEntries = [
+            'http://web/api/ezp/v2/bookmark/43 - Failed to load resource: the server responded with a status of 404 (Not Found)',
+            'https://varnish/api/ezp/v2/bookmark/1 - Failed to load resource: the server responded with a status of 404 (Not Found)',
+            'Real JS Error',
+            'http://varnish/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.',
+            'https://web/bundles/netgentags/admin/jstree/js/jstree.min.js 5 document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272 for more details.',
+            'Another real JS error',
+            'http://web.prod/admin/version-draft/has-no-conflict/124/eng-GB - Failed to load resource: the server responded with a status of 409 (Conflict)',
+            'http://varnish.prod/admin/version-draft/has-no-conflict/1/pol-PL - Failed to load resource: the server responded with a status of 409 (Conflict)',
+            'webpack:///./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/public/js/scripts/fieldType/ezobjectrelationlist.js? 91:12 "EzObjectRelation fieldtype is deprecated. Please, use EzObjectRelationList fieldtype instead."',
+            ];
+
+        $filter = new BrowserLogFilter();
+        $actualResult = $filter->filter($initialLogEntries);
+
+        Assert::assertEquals(['Real JS Error', 'Another real JS error'], $actualResult);
+    }
+}

--- a/tests/Core/Behat/ExtendedTableNodeTest.php
+++ b/tests/Core/Behat/ExtendedTableNodeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Test\Core\Behat;
+
+use Behat\Gherkin\Node\TableNode;
+use EzSystems\Behat\Core\Behat\TableNodeExtension;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+class ExtendedTableNodeTest extends TestCase
+{
+    private const MULTIPLE_ROW_DATA = [['Header1', 'Header2', 'Header3'],
+        ['Value11', 'Value12', 'Value13'],
+        ['Value21', 'Value22', 'Value23'], ];
+
+    private const SINGLE_ROW_DATA = [['Header1', 'Header2', 'Header3'],
+        ['Value11', 'Value12', 'Value13'], ];
+
+    public function testCanAddNewColumnWithSingleValue()
+    {
+        $beforeTable = new TableNode(self::SINGLE_ROW_DATA);
+        $columnToAdd = ['Header4' => 'Value14'];
+
+        $afterTable = TableNodeExtension::addColumn($beforeTable, $columnToAdd);
+
+        Assert::assertEquals([['Header1', 'Header2', 'Header3', 'Header4'],
+            ['Value11', 'Value12', 'Value13', 'Value14'], ], $afterTable->getTable());
+    }
+
+    public function testCanAddNewColumnWithMultipleValues()
+    {
+        $beforeTable = new TableNode(self::MULTIPLE_ROW_DATA);
+        $columnToAdd = ['Header4' => ['Value14', 'Value24']];
+
+        $afterTable = TableNodeExtension::addColumn($beforeTable, $columnToAdd);
+
+        Assert::assertEquals([['Header1', 'Header2', 'Header3', 'Header4'],
+            ['Value11', 'Value12', 'Value13', 'Value14'],
+            ['Value21', 'Value22', 'Value23', 'Value24'], ], $afterTable->getTable());
+    }
+
+    public function testCanAddNewColumnsWithSingleValues()
+    {
+        $beforeTable = new TableNode(self::SINGLE_ROW_DATA);
+        $columnToAdd = ['Header4' => 'Value14', 'Header5' => 'Value15'];
+
+        $afterTable = TableNodeExtension::addColumn($beforeTable, $columnToAdd);
+
+        Assert::assertEquals([['Header1', 'Header2', 'Header3', 'Header4', 'Header5'],
+            ['Value11', 'Value12', 'Value13', 'Value14', 'Value15'], ], $afterTable->getTable());
+    }
+
+    public function testCanAddNewColumnsWithMultipleValues()
+    {
+        $beforeTable = new TableNode(self::MULTIPLE_ROW_DATA);
+        $columnToAdd = ['Header4' => ['Value14', 'Value24'], 'Header5' => ['Value15', 'Value25']];
+
+        $afterTable = TableNodeExtension::addColumn($beforeTable, $columnToAdd);
+
+        Assert::assertEquals([['Header1', 'Header2', 'Header3', 'Header4', 'Header5'],
+            ['Value11', 'Value12', 'Value13', 'Value14', 'Value15'],
+            ['Value21', 'Value22', 'Value23', 'Value24', 'Value25'], ], $afterTable->getTable());
+    }
+}

--- a/tests/Core/Configuration/ConfigurationEditorTest.php
+++ b/tests/Core/Configuration/ConfigurationEditorTest.php
@@ -4,7 +4,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace EzSystems\Behat\Test;
+namespace EzSystems\Behat\Test\Core\Configuration;
 
 use EzSystems\Behat\Core\Configuration\ConfigurationEditor;
 use PHPUnit\Framework\Assert;


### PR DESCRIPTION
JIRA: [EZP-30668](jira.ez.no/browse/EZP-30668)

Moving core AdminUI test classes to BehatBundle.

Requires:
https://github.com/ezsystems/ezplatform-page-builder/pull/356
https://github.com/ezsystems/ezplatform-form-builder/pull/171
https://github.com/ezsystems/date-based-publisher/pull/114
https://github.com/ezsystems/flex-workflow/pull/132
https://github.com/ezsystems/repository-forms/pull/300
https://github.com/ezsystems/ezplatform-admin-ui/pull/1020
https://github.com/ezsystems/ezplatform-ee-demo/pull/148

Moved:
- `EzSystems\EzPlatformAdminUi\Behat\PageElement\Element` -> `EzSystems\Behat\Browser\Element\Element`
- `EzSystems\EzPlatformAdminUi\Behat\PageElement\ElementFactory` -> `EzSystems\Behat\Browser\Factory\ElementFactory`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\BrowserLogFIlter` -> `EzSystems\Behat\Browser\Filter\BrowserLogFilter`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\Environment` ->`EzSystems\Behat\Core\Environment\Environment`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\ EzEnvironmentConstants` -> `EzSystems\Behat\Core\Environment\EnvironmentConstants`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\Hooks` -> `EzSystems\Behat\Browser\Context\Hooks`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\UtilityContext` -> `EzSystems\Behat\Browser\Context\BrowserContext`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\InstallType` -> `EzSystems\Behat\Core\Environment\InstallType`
- `EzSystems\EzPlatformAdminUi\Behat\Helper\TableNodeExtension` -> `EzSystems\Behat\Core\Behat\TableNodeExtension`
- `EzSystems\EzPlatformAdminUi\Behat\PageObject\FolderPreview` -> `EzSystems\Behat\Browser\Page\Preview\FolderPreview`
- `EzSystems\EzPlatformAdminUi\Behat\PageObject\Page` -> `EzSystems\Behat\Browser\Page\Page`
- `EzSystems\EzPlatformAdminUi\Behat\PageObject\PageObjectFactory` -> `EzSystems\Behat\Browser\Factory\PageObjectFactory`
- `drag-mock` library
- UnitTests for Behat

Extracted `FieldTypeNameConverter` from `EzFieldElement`.