### PR TITLE
EZP-30668: Refactored tests to use the extracted fieldtype converter

### DIFF
--- a/src/lib/API/Facade/ContentTypeFacade.php
+++ b/src/lib/API/Facade/ContentTypeFacade.php
@@ -6,9 +6,9 @@
  */
 namespace EzSystems\Behat\API\Facade;
 
+use EzSystems\Behat\API\ContentData\FieldTypeNameConverter;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement;
 
 class ContentTypeFacade
 {
@@ -48,7 +48,6 @@ class ContentTypeFacade
 
     public function getFieldTypeIdentifierByName(string $fieldtypeName): string
     {
-        // TODO: When refactoring in AdminUI move the mappings here
-        return EzFieldElement::getFieldInternalNameByName($fieldtypeName);
+        return FieldTypeNameConverter::getFieldTypeIdentifierByName($fieldtypeName);
     }
 }


### PR DESCRIPTION
Something that was missed in https://github.com/ezsystems/BehatBundle/pull/87 - this has to be changed to the refactored Converter, otherwise the tests are failing with: 
```
        Fatal error: Call to undefined method EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement::getFieldInternalNameByName() (Behat\Testwork\Call\Exception\FatalThrowableError)
```
Example: https://travis-ci.org/ezsystems/BehatBundle/jobs/554585793