### PR TITLE
Fix EE-DEMO type detection

### DIFF
--- a/src/lib/Browser/Context/Hooks.php
+++ b/src/lib/Browser/Context/Hooks.php
@@ -42,7 +42,10 @@ class Hooks extends RawMinkContext
     /** @BeforeScenario */
     public function setInstallTypeBeforeScenario()
     {
-        $env = new Environment($this->getContainer());
+        $container = $this->getContainer();
+        $container = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
+
+        $env = new Environment($container);
         $installType = $env->getInstallType();
 
         PageObjectFactory::setInstallType($installType);

--- a/src/lib/Core/Environment/Environment.php
+++ b/src/lib/Core/Environment/Environment.php
@@ -18,7 +18,7 @@ class Environment
     private $installerServices = ['platform' => 'ezplatform.installer.clean_installer',
         'platform-demo' => 'app.installer.demo_installer',
         'platform-ee' => 'ezstudio.installer.studio_installer',
-        'platform-ee-demo' => 'app.installer.ee-demo_installer', ];
+        'platform-ee-demo' => 'App\Installer\PlatformEEDemoInstaller', ];
 
     /**
      * Environment constructor.


### PR DESCRIPTION
Another issue detected when working on https://github.com/ezsystems/ezplatform-page-builder/pull/374

Currently tests are not running correctly on ee-demo, because the install type is not correctly set. This is because the installer service definition has changed.

Installer service definitions:
https://github.com/ezsystems/ezplatform-ee-demo/blob/master/config/services/installer.yaml
https://github.com/ezsystems/ezplatform-ee-demo/blob/2.5/app/config/services/installer.yml#L7

We have to adjust for that (changing from `app.installer.ee-demo_installer` to `App\Installer\PlatformEEDemoInstaller`).

But this is not enough, as the service is now private by default - to get it directly from the container we have to use the test container (similar as it was in https://github.com/ezsystems/ezplatform/pull/443)
