### PR TITLE
Adjusted namespaces after Demo has been adapted for 3.0

### DIFF
--- a/src/lib/Browser/Factory/ElementFactory.php
+++ b/src/lib/Browser/Factory/ElementFactory.php
@@ -10,7 +10,7 @@ use EzSystems\Behat\Browser\Context\BrowserContext;
 use EzSystems\Behat\Core\Environment\InstallType;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\PlatformElementFactory;
 use EzSystems\EzPlatformPageBuilder\Tests\Behat\PageElement\EnterpriseElementFactory;
-use Tests\AppBundle\Behat\PageElement\DemoEnterpriseElementFactory;
+use Tests\App\Behat\PageElement\DemoEnterpriseElementFactory;
 
 class ElementFactory
 {

--- a/src/lib/Browser/Factory/PageObjectFactory.php
+++ b/src/lib/Browser/Factory/PageObjectFactory.php
@@ -11,7 +11,7 @@ use EzSystems\Behat\Browser\Page\FrontendLoginPage;
 use EzSystems\Behat\Core\Environment\InstallType;
 use EzSystems\EzPlatformAdminUi\Behat\PageObject\PlatformPageObjectFactory;
 use EzSystems\EzPlatformPageBuilder\Tests\Behat\PageObject\EnterprisePageObjectFactory;
-use Tests\AppBundle\Behat\PageObject\DemoEnterprisePageObjectFactory;
+use Tests\App\Behat\PageObject\DemoEnterprisePageObjectFactory;
 
 class PageObjectFactory
 {

--- a/src/lib/Core/Environment/EnvironmentConstants.php
+++ b/src/lib/Core/Environment/EnvironmentConstants.php
@@ -9,7 +9,7 @@ namespace EzSystems\Behat\Core\Environment;
 use EzSystems\EzPlatformAdminUi\Behat\Environment\PlatformEnvironmentConstants;
 use EzSystems\EzPlatformPageBuilder\Tests\Behat\Environment\EnterpriseEnvironmentConstants;
 use Tests\AppBundle\Behat\PlatformDemoEnvironmentConstants;
-use Tests\AppBundle\Behat\EnterpriseDemoEnvironmentConstants;
+use Tests\App\Behat\EnterpriseDemoEnvironmentConstants;
 
 class EnvironmentConstants
 {


### PR DESCRIPTION
As an ongoing work on https://github.com/ezsystems/ezplatform-page-builder/pull/374, now the error is:
```
  Given I am logged as admin # EzSystems\EzPlatformAdminUi\Behat\BusinessContext\AuthenticationContext::iAmLoggedAs()

      Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Class 'Tests\AppBundle\Behat\PageObject\DemoEnterprisePageObjectFactory' not found in vendor/ezsystems/behatbundle/src/lib/Browser/Factory/PageObjectFactory.php:72
```

This is caused by https://github.com/ezsystems/ezplatform-ee-demo/pull/150, which changed namespaces for all classes in AppBundle (from `/AppBundle/` to `/App`/)/.

Moved files:
https://github.com/ezsystems/ezplatform-ee-demo/blob/master/tests/App/Behat/PageElement/DemoEnterpriseElementFactory.php
https://github.com/ezsystems/ezplatform-ee-demo/blob/master/tests/App/Behat/PageObject/DemoEnterprisePageObjectFactory.php
https://github.com/ezsystems/ezplatform-ee-demo/blob/master/tests/App/Behat/EnterpriseDemoEnvironmentConstants.php

I've left `Tests\AppBundle\Behat\PlatformDemoEnvironmentConstants`, because ezplatform-demo is not ready for 3.0 yet (and this namespace is still correct).