### PR TITLE
Implemented setup for subtreeEditor

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,6 +26,15 @@ return PhpCsFixer\Config::create()
         ],
         'yoda_style' => false,
         'no_break_comment' => false,
+        'native_function_invocation' => false,
+        'native_constant_invocation' => false,
+        'phpdoc_types_order' => false,
+        'php_unit_mock_short_will_return' => false,
+        'php_unit_construct' => false,
+        'php_unit_dedicate_assert' => true,
+        'php_unit_dedicate_assert_internal_type' => true,
+        'standardize_increment' => false,
+        'fopen_flags' => false,
         'self_accessor' => false,
     ])
     ->setRiskyAllowed(true)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,12 @@ matrix:
       env: CHECK_CS=1
     - name: "Unit tests"
       env: PHPUNIT_CONFIG='phpunit.xml'
-    - name: "BehatBundle tests"
+    - name: "BehatBundle examples tests"
       php: 7.3
       env: BEHAT_OPTS="--profile=behat"
+    - name: "BehatBundle personas tests"
+      php: 7.3
+      env: BEHAT_OPTS="--mode=behat --profile=setup --suite=personas"
     - name: "AdminUI Modules tests"
       php: 7.3
       env:

--- a/API/Facade/ContentTypeFacade.php
+++ b/API/Facade/ContentTypeFacade.php
@@ -19,11 +19,12 @@ class ContentTypeFacade
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function createContentType(string $contentTypeName, string $contentTypeIdentifier, string $contentTypeGroupName, string $mainLanguageCode, array $fieldDefinitions)
+    public function createContentType(string $contentTypeName, string $contentTypeIdentifier, string $contentTypeGroupName, string $mainLanguageCode, bool $isContainer, array $fieldDefinitions)
     {
         $contentTypeCreateStruct = $this->contentTypeService->newContentTypeCreateStruct($contentTypeIdentifier);
         $contentTypeCreateStruct->names = [$mainLanguageCode => $contentTypeName];
         $contentTypeCreateStruct->mainLanguageCode = $mainLanguageCode;
+        $contentTypeCreateStruct->isContainer = $isContainer;
 
         foreach ($fieldDefinitions as $definition) {
             $contentTypeCreateStruct->addFieldDefinition($definition);

--- a/API/Facade/UserFacade.php
+++ b/API/Facade/UserFacade.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use EzSystems\BehatBundle\API\ContentData\ContentDataProvider;
 use EzSystems\BehatBundle\API\ContentData\FieldTypeData\PasswordProvider;
@@ -49,7 +50,7 @@ class UserFacade
         $this->userService->createUserGroup($userGroupStruct, $parentGroup);
     }
 
-    public function createUser($userName, $userGroupName = null, $languageCode = 'eng-GB')
+    public function createUser($userName, $userLastName, $userGroupName = null, $languageCode = 'eng-GB')
     {
         $userCreateStruct = $this->userService->newUserCreateStruct(
             $userName,
@@ -59,7 +60,7 @@ class UserFacade
             $this->contentTypeService->loadContentTypeByIdentifier(self::USER_CONTENT_TYPE_IDENTIFIER));
 
         $userCreateStruct->setField('first_name', $userName);
-        $userCreateStruct->setField('last_name', $this->contentDataProvider->getRandomFieldData('ezstring', $languageCode));
+        $userCreateStruct->setField('last_name', $userLastName);
 
         $parentGroup = $userGroupName !== null ?
             $this->loadUserGroupByName($userGroupName) :
@@ -76,12 +77,12 @@ class UserFacade
         $this->roleService->assignRoleToUser($role, $user);
     }
 
-    public function assignUserGroupToRole($userGroupName, $roleName)
+    public function assignUserGroupToRole($userGroupName, $roleName, ?RoleLimitation $roleLimitation = null)
     {
         $group = $this->loadUserGroupByName($userGroupName);
         $role = $this->roleService->loadRoleByIdentifier($roleName);
 
-        $this->roleService->assignRoleToUserGroup($role, $group);
+        $this->roleService->assignRoleToUserGroup($role, $group, $roleLimitation);
     }
 
     public function getDefaultPassword(): string

--- a/Context/Api/LimitationParser/LocationLimitationParser.php
+++ b/Context/Api/LimitationParser/LocationLimitationParser.php
@@ -10,16 +10,19 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
+use EzSystems\BehatBundle\Helper\ArgumentParser;
 
 class LocationLimitationParser implements LimitationParserInterface
 {
     private $locationService;
     private $urlAliasService;
+    private $argumentParser;
 
-    public function __construct(URLAliasService $urlAliasService, LocationService $locationService)
+    public function __construct(URLAliasService $urlAliasService, LocationService $locationService, ArgumentParser $argumentParser)
     {
         $this->urlAliasService = $urlAliasService;
         $this->locationService = $locationService;
+        $this->argumentParser = $argumentParser;
     }
 
     public function supports(string $limitationType): bool
@@ -32,7 +35,8 @@ class LocationLimitationParser implements LimitationParserInterface
         $values = [];
 
         foreach (explode(',', $limitationValues) as $limitationValue) {
-            $urlAlias = $this->urlAliasService->lookup($limitationValue);
+            $parsedUrl = $this->argumentParser->parseUrl($limitationValue);
+            $urlAlias = $this->urlAliasService->lookup($parsedUrl);
             $location = $this->locationService->loadLocation($urlAlias->destination);
             $values[] = $location->id;
         }

--- a/Context/Object/ContentTypeContext.php
+++ b/Context/Object/ContentTypeContext.php
@@ -31,7 +31,7 @@ class ContentTypeContext implements Context
         }
 
         $fieldDefinitions = $this->parseFieldDefinitions($fieldDetails);
-        $this->contentTypeFacade->createContentType($contentTypeName, $contentTypeIdentifier, $contentTypeGroupName, 'eng-GB', $fieldDefinitions);
+        $this->contentTypeFacade->createContentType($contentTypeName, $contentTypeIdentifier, $contentTypeGroupName, 'eng-GB', true, $fieldDefinitions);
     }
 
     private function parseFieldDefinitions(TableNode $fieldDetails): array

--- a/Context/Object/RoleContext.php
+++ b/Context/Object/RoleContext.php
@@ -9,15 +9,20 @@ namespace EzSystems\BehatBundle\Context\Object;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use EzSystems\BehatBundle\API\Facade\RoleFacade;
+use EzSystems\BehatBundle\Helper\ArgumentParser;
 
 class RoleContext implements Context
 {
     /** @var RoleFacade */
     private $roleFacade;
 
-    public function __construct(RoleFacade $roleFacade)
+    /** @var ArgumentParser */
+    private $argumentParser;
+
+    public function __construct(RoleFacade $roleFacade, ArgumentParser $argumentParser)
     {
         $this->roleFacade = $roleFacade;
+        $this->argumentParser = $argumentParser;
     }
 
     /**
@@ -63,24 +68,7 @@ class RoleContext implements Context
      */
     public function addPolicyToRoleWithLimitation(string $module, string $function, $roleName, TableNode $limitations): void
     {
-        $parsedLimitations = $this->parseLimitations($limitations);
+        $parsedLimitations = $this->argumentParser->parseLimitations($limitations);
         $this->roleFacade->addPolicyToRole($roleName, $module, $function, $parsedLimitations);
-    }
-
-    private function parseLimitations(TableNode $limitations)
-    {
-        $parsedLimitations = [];
-        $limitationParsers = $this->roleFacade->getLimitationParsers();
-
-        foreach ($limitations->getHash() as $rawLimitation) {
-            foreach ($limitationParsers as $parser) {
-                if ($parser->supports($rawLimitation['limitationType'])) {
-                    $parsedLimitations[] = $parser->parse($rawLimitation['limitationValue']);
-                    break;
-                }
-            }
-        }
-
-        return $parsedLimitations;
     }
 }

--- a/Features/personas/subtree_editor.feature
+++ b/Features/personas/subtree_editor.feature
@@ -1,0 +1,52 @@
+Feature: Editor that has access only to a Subtree of Content Structure
+
+  @admin @setup @subtreeEditor
+  Scenario: Create a Role and assign policies with limitations to it
+    Given I create a "DedicatedFolder" Content Type in "Content" with "dedicatedFolder" identifier
+      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable |
+      | Text line   | Name         | name	           | yes      | yes	       | yes          |
+      | Text line   | Short name   | short_name        | yes      | no	       | yes          |
+    And I create "DedicatedFolder" Content items in root in "eng-GB"
+      | name              | short_name        |
+      | FolderGrandParent | FolderGrandParent |
+    And I create "DedicatedFolder" Content items in "FolderGrandParent" in "eng-GB"
+      | name         | short_name   |
+      | FolderParent | FolderParent |
+    And I create "DedicatedFolder" Content items in "FolderGrandParent/FolderParent" in "eng-GB"
+      | name         | short_name   |
+      | FolderChild1 | FolderChild1 |
+      | FolderChild2 | FolderChild2 |
+    And I create "DedicatedFolder" Content items in "FolderGrandParent/FolderParent/FolderChild1" in "eng-GB"
+      | name          | short_name    |
+      | ContentToMove | ContentToMove |
+    And I create a user group "SubtreeEditorsGroup"
+    And I create a user "SubtreeEditor" with last name "Subtree Editor" in group "SubtreeEditorsGroup"
+    And I create a role "BasicRole" with policies
+      | module      | function   |
+      | user        | login      |
+    And I create a user "ThisUserIsAReviewer" with last name "Test" in group "SubtreeEditorsGroup"
+    And I add policy "content" "read" to "BasicRole" with limitations
+      | limitationType      | limitationValue                                    |
+      | Location            | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test |
+    And I create a role "SubtreeEditorsRole" with policies
+      | module      | function           |
+      | content     | read               |
+      | content     | create             |
+      | content     | publish            |
+      | content     | remove             |
+      | content     | edit               |
+      | section     | view               | 
+      | content     | versionread        |
+      | content     | reverserelatedlist |
+    And I create a role "ReadNodesForSubtreeEditors"
+    And I add policy "content" "read" to "ReadNodesForSubtreeEditors" with limitations
+      | limitationType      | limitationValue         |
+      | Location            | root,/FolderGrandParent |
+    And I add policy "content" "versionread" to "ReadNodesForSubtreeEditors" with limitations
+      | limitationType      | limitationValue         |
+      | Location            | root,/FolderGrandParent |
+    And I assign user group "SubtreeEditorsGroup" to role "BasicRole"
+    And I assign user group "SubtreeEditorsGroup" to role "ReadNodesForSubtreeEditors"
+    And I assign user group "SubtreeEditorsGroup" to role "SubtreeEditorsRole" with limitations:
+      | limitationType      | limitationValue                 |
+      | Subtree             | /FolderGrandParent/FolderParent |

--- a/Features/user.feature
+++ b/Features/user.feature
@@ -103,7 +103,7 @@ Feature: User Creation
     @admin
     Scenario: Create Users, User groups and assign them to Roles
         Given I create a user group "MyGroup"
-        And I create a user "TestUser"
-        And I create a user "AnotherTestUser" in group "MyGroup"
+        And I create a user "TestUser" with last name "TestLastName"
+        And I create a user "AnotherTestUser" with last name "TestLastName" in group "MyGroup"
         And I assign user "TestUser" to role "simpleRole"
         And I assign user group "MyGroup" to role "complexRole"

--- a/Helper/ArgumentParser.php
+++ b/Helper/ArgumentParser.php
@@ -6,8 +6,29 @@
  */
 namespace EzSystems\BehatBundle\Helper;
 
+use Behat\Gherkin\Node\TableNode;
+use EzSystems\BehatBundle\API\Facade\RoleFacade;
+use EzSystems\EzPlatformAdminUi\Behat\Helper\EzEnvironmentConstants;
+
 class ArgumentParser
 {
+    private const ROOT_KEYWORD = 'root';
+
+    public function __construct(RoleFacade $roleFacade)
+    {
+        $this->roleFacade = $roleFacade;
+    }
+
+    /**
+     * Generates URLAlias value based on given Content Path.
+     *
+     * Example: Home/New Folder => /Home/New-Folder
+     * Example: root => /
+     *
+     * @param string $url
+     *
+     * @return mixed|string
+     */
     public function parseUrl(string $url)
     {
         if ($url === 'root') {
@@ -17,5 +38,36 @@ class ArgumentParser
         $url = str_replace(' ', '-', $url);
 
         return strpos($url, '/') === 0 ? $url : sprintf('/%s', $url);
+    }
+
+    public function parseLimitations(TableNode $limitations)
+    {
+        $parsedLimitations = [];
+        $limitationParsers = $this->roleFacade->getLimitationParsers();
+
+        foreach ($limitations->getHash() as $rawLimitation) {
+            foreach ($limitationParsers as $parser) {
+                if ($parser->supports($rawLimitation['limitationType'])) {
+                    $parsedLimitations[] = $parser->parse($rawLimitation['limitationValue']);
+                    break;
+                }
+            }
+        }
+
+        return $parsedLimitations;
+    }
+
+    /**
+     * Replaces the 'root' keyword with the name of the real root Content Item.
+     *
+     * Example: root/MyItem1 => eZ Platform/MyItem1 on ezplatform and Home/MyItem1 on ezplatform-ee
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function replaceRootKeyword(string $path): string
+    {
+        return str_replace(self::ROOT_KEYWORD, EzEnvironmentConstants::get('ROOT_CONTENT_NAME'), $path);
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -37,3 +37,5 @@ services:
 
     EzSystems\BehatBundle\Helper\ArgumentParser:
         public: true
+        arguments:
+            - '@EzSystems\BehatBundle\API\Facade\RoleFacade'

--- a/Resources/config/services/limitation_parsers.yaml
+++ b/Resources/config/services/limitation_parsers.yaml
@@ -16,6 +16,7 @@ services:
         arguments:
             - '@ezpublish.api.service.url_alias'
             - '@ezpublish.api.service.location'
+            - '@EzSystems\BehatBundle\Helper\ArgumentParser'
 
     EzSystems\BehatBundle\Context\Api\LimitationParser\NewSectionLimitationParser:
         arguments:

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -11,8 +11,10 @@ behat:
                       permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
                 - EzSystems\BehatBundle\Context\Object\UserContext:
                       userFacade: '@EzSystems\BehatBundle\API\Facade\UserFacade'
+                      argumentParser: '@EzSystems\BehatBundle\Helper\ArgumentParser'
                 - EzSystems\BehatBundle\Context\Object\RoleContext:
                       roleFacade: '@EzSystems\BehatBundle\API\Facade\RoleFacade'
+                      argumentParser: '@EzSystems\BehatBundle\Helper\ArgumentParser'
                 - EzSystems\BehatBundle\Context\Object\LanguageContext:
                       languageFacade: '@EzSystems\BehatBundle\API\Facade\LanguageFacade'
                 - EzSystems\BehatBundle\Context\Object\ObjectStateContext:
@@ -64,3 +66,21 @@ setup:
                       projectDir: '%paths.base%'
                 - EzSystems\BehatBundle\Context\FileContext:
                       basePath: '%paths.base%'
+        personas:
+              paths:
+                - '%paths.base%/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Features/personas'
+              contexts:
+                - EzSystems\BehatBundle\Context\Api\TestContext:
+                    userService: '@ezpublish.api.service.user'
+                    permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
+                - EzSystems\BehatBundle\Context\Object\UserContext:
+                    userFacade: '@EzSystems\BehatBundle\API\Facade\UserFacade'
+                    argumentParser: '@EzSystems\BehatBundle\Helper\ArgumentParser'
+                - EzSystems\BehatBundle\Context\Object\RoleContext:
+                    roleFacade: '@EzSystems\BehatBundle\API\Facade\RoleFacade'
+                    argumentParser: '@EzSystems\BehatBundle\Helper\ArgumentParser'
+                - EzSystems\BehatBundle\Context\Object\ContentContext:
+                    contentFacade: '@EzSystems\BehatBundle\API\Facade\ContentFacade'
+                    argumentParser: '@EzSystems\BehatBundle\Helper\ArgumentParser'
+                - EzSystems\BehatBundle\Context\Object\ContentTypeContext:
+                    contentTypeFacade: '@EzSystems\BehatBundle\API\Facade\ContentTypeFacade'

--- a/tests/Helper/ArgumentParserTest.php
+++ b/tests/Helper/ArgumentParserTest.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\BehatBundle\Test\Helper;
 
+use EzSystems\BehatBundle\API\Facade\RoleFacade;
 use EzSystems\BehatBundle\Helper\ArgumentParser;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,9 @@ class ArgumentParserTest extends TestCase
      */
     public function testParserGivenUrlCorrectly(string $valueToParse, string $expectedResult)
     {
-        $parser = new ArgumentParser();
+        $roleFacadeStub = $this->createMock(RoleFacade::class);
+
+        $parser = new ArgumentParser($roleFacadeStub);
 
         $actualResult = $parser->parseUrl($valueToParse);
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30884

This PR:
1) adds some missing config options for cs-fixer (for reference: https://github.com/ezsystems/ezpublish-kernel/blob/7.5/.php_cs)
2) adds support for assigning user to role with limitations
3) adds a new personas suite with 1 Persona: SubtreeEditor

SubtreeEditor feature:
1) I've given him read/create/edit/publish access only to part of a Subtree, with required permissions added so that he can use Content Tree and PageBuilder
2) I've created Content Items that he will be interacting with (also an another, new User so that he can use flex-workflow and send him something for review)

# Testing:
you can get all required dependencies using:
git clone github.com/mnocon/ezplatform.git -b EZP-30884-implement-user (ezplatform)
git clone github.com/mnocon/ezplatform-ee.git -b EZP-30884-implement-user (ezplatform-ee)

To run the suite:
`bin/behat --profile=setup --suite=personas`

Login as SubtreeEditor with password `Passw0rd-42`.

Related PRs:
https://github.com/ezsystems/ezpublish-kernel/pull/2750
https://github.com/ezsystems/ezplatform-page-builder/pull/384
https://github.com/ezsystems/ezplatform-admin-ui/pull/1068
https://github.com/ezsystems/ezplatform/pull/451