### PR TITLE
EZP-30898: Dropped dependency on Installers to get InstallType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3",
+        "ext-json": "*",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "fzaninotto/faker": "^1.8",
         "behat/behat": "^3.5",

--- a/src/lib/Core/Environment/InstallType.php
+++ b/src/lib/Core/Environment/InstallType.php
@@ -12,4 +12,11 @@ abstract class InstallType
     public const PLATFORM_DEMO = 2;
     public const ENTERPRISE = 3;
     public const ENTERPRISE_DEMO = 4;
+
+    public const PACKAGE_NAME_MAP = [
+        'ezsystems/ezplatform' => InstallType::PLATFORM,
+        'ezsystems/ezplatform-ee' => InstallType::ENTERPRISE,
+        'ezsystems/ezplatform-demo' => InstallType::PLATFORM_DEMO,
+        'ezsystems/ezplatform-ee-demo' => InstallType::ENTERPRISE_DEMO,
+    ];
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30898](https://jira.ez.no/browse/EZP-30898)
| **Required by** | ezsystems/ezpublish-kernel#2751
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0` Behat tests.
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR drops dependency on Installer services defined in the Service Container as there's a simpler method. It's required by ezsystems/ezpublish-kernel#2751 but **independent**. 

I've chosen this solution because I wouldn't recommend maintaining the changed list of service names as there's really no BC promise for that, nor there should be one.

I can improve this one further by moving more responsibility to InstallerType (w/ changed name and dropped `abstract`), if you want :)

### QA
- [ ] Needs testing with all the metas (preferred manually, not all suites, just some random one to check if it works,
- [ ] Needs testing when ran from a dependency, not meta (haven't tried that :sweat_smile:).