### PR TITLE
Added Twig PHPType extension

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -43,6 +43,10 @@ services:
         tags:
             - { name: console.command }
 
+    EzSystems\BehatBundle\Templating\Twig\PHPTypeExtension:
+        tags:
+            - { name: twig.extension }
+
     EzSystems\BehatBundle\Command\TestSiteaccessCommand:
         arguments:
             $siteaccess: '@ezpublish.siteaccess'

--- a/src/bundle/Resources/views/tests/dump.html.twig
+++ b/src/bundle/Resources/views/tests/dump.html.twig
@@ -2,4 +2,8 @@
 
 <p>Result of <pre style="display: inline">dump()</pre>:</p>
 
-{{ dump() }}
+<ol class="dump">
+    {% for key, value in _context  %}
+            <li class="item"><var class="variable">{{ key }}</var>:<var class="type">{{ value|php_type }}</var></li>
+    {% endfor %}
+</ol>

--- a/src/bundle/Templating/Twig/PHPTypeExtension.php
+++ b/src/bundle/Templating/Twig/PHPTypeExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Templating\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class PHPTypeExtension extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('php_type', function ($var) {
+                $type = gettype($var);
+
+                if ($type === 'object') {
+                    return get_class($var);
+                }
+
+                return $type;
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds a Twig extension that displays variables and their type in Twig template and uses it in dump.html.twig

Twig extension code is based heavily on an example provided by @adamwojs , I don't think we need to expand it further right now.

It will be used in https://github.com/ezsystems/ezpublish-kernel/pull/2887 . How the template looks:
![obraz](https://user-images.githubusercontent.com/10993858/69724140-8caa9480-111b-11ea-999e-86d132c74c73.png)

