### PR TITLE
EZEE-2928: Removed dependency on EE in examples

### DIFF
--- a/features/examples/configuration.feature
+++ b/features/examples/configuration.feature
@@ -11,53 +11,12 @@ Feature: Example scenarios showing how to set configuration
       | languages                    | pol-PL |
       | page_builder.siteaccess_list | pol    |
 
-  Scenario: Create specified workflows
-    Given I set configuration to "default" siteaccess under "workflows" key
+  Scenario: Configure Varnish as http cache
+    Given I set configuration to "ezplatform.http_cache"
     """
-      article_workflow:
-          name: 'Article Workflow'
-          matchers:
-              content_type: article
-          stages:
-              draft:
-                  label: 'Draft'
-                  color: '#4a69bd'
-              done:
-                  color: '#0f0'
-                  last_stage: true
-          initial_stage: draft
-          transitions:
-              done:
-                  from: draft
-                  to: done
-                  icon: '/bundles/ezplatformadminui/img/ez-icons.svg#approved'
-                  label: 'Back to Done'
-              back_to_draft:
-                  reverse: done
-                  icon: '/bundles/ezplatformadminui/img/ez-icons.svg#rejected'
-                  label: 'Back to Draft'
+        purge_type: 'http'
     """
-    And I append configuration to "default" siteaccess under "workflows" key
+    And  I append configuration to "default" siteaccess under "http_cache" key
     """
-    folder_workflow:
-        name: 'Folder Workflow'
-        matchers:
-            content_type: folder
-        stages:
-            draft:
-                label: 'Draft'
-                color: '#0f0'
-            done:
-                color: '#4a69bd'
-                last_stage: true
-        initial_stage: draft
-        transitions:
-            done:
-                from: draft
-                to: done
-                icon: '/bundles/ezplatformadminui/img/ez-icons.svg#approved'
-            back_to_draft:
-                reverse: done
-                icon: '/bundles/ezplatformadminui/img/ez-icons.svg#rejected'
-                label: 'Back to Draft'
+        purge_servers: ['http://my_purge_server']
     """


### PR DESCRIPTION
Done as part of https://jira.ez.no/browse/EZEE-2928


Merging:
- 2.5 still uses `ezpublish` key - https://github.com/ezsystems/ezplatform/blob/2.5/app/config/ezplatform.yml#L1 .Needs to be changed to `ezplatform` when merging upstream: https://github.com/ezsystems/ezplatform/blob/master/config/packages/ezplatform.yaml#L35

Description:
Current example relies on EE (page_builder setting), this PR tries to make an example that can be run using open source version.

This is required by: https://github.com/ezsystems/ezplatform/pull/485