### PR TITLE
EZEE-2928: Removed PageBuilder from examples

### DIFF
--- a/features/examples/configuration.feature
+++ b/features/examples/configuration.feature
@@ -1,7 +1,7 @@
 Feature: Example scenarios showing how to set configuration
 
   @admin
-  Scenario: Add a language. Create a siteaccess using it and add it to PageBuilder
+  Scenario: Add a language. Create a siteaccess using it.
     Given Language "Polski" with code "pol-PL" exists
     And I add a siteaccess "pol" to "site_group" with settings
       | key       | value         |
@@ -9,7 +9,6 @@ Feature: Example scenarios showing how to set configuration
     And I append configuration to "admin_group" siteaccess
       | key                          | value  |
       | languages                    | pol-PL |
-      | page_builder.siteaccess_list | pol    |
 
   Scenario: Configure Varnish as http cache
     Given I set configuration to "ezplatform.http_cache"


### PR DESCRIPTION
Follow-up to https://github.com/ezsystems/BehatBundle/pull/117, because I focused too much on the workflow test and missed the page_builder mention 🙈 

This time I've added the dependency to https://github.com/ezsystems/ezplatform/pull/485 and it's green, so this should be the last PR in the series.