### PR TITLE
Changed configuration key to ezpublish from ezplatform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,15 @@ matrix:
       env: PHPUNIT_CONFIG='phpunit.xml'
     - name: "BehatBundle examples"
       php: 7.3
-      env: BEHAT_OPTS="--profile=behat --suite=examples"
+      env: BEHAT_OPTS="--mode=standard --profile=behat --suite=examples"
     - name: "BehatBundle personas tests"
       php: 7.3
-      env: BEHAT_OPTS="--mode=behat --profile=setup --suite=personas"
+      env: BEHAT_OPTS="--mode=standard --profile=setup --suite=personas"
     - name: "AdminUI Modules tests"
       php: 7.3
       env:
-        -SETUP_BEHAT_OPTS="--mode=behat --profile=setup --suite=richtext_configuration"
-        -BEHAT_OPTS="--mode=behat --profile=adminui --suite=adminuimodules"
+        -SETUP_BEHAT_OPTS="--mode=standard --profile=setup --suite=richtext_configuration"
+        -BEHAT_OPTS="--mode=standard --profile=adminui --suite=adminuimodules"
 
 git:
   depth: 30

--- a/features/examples/configuration.feature
+++ b/features/examples/configuration.feature
@@ -11,7 +11,7 @@ Feature: Example scenarios showing how to set configuration
       | languages                    | pol-PL |
 
   Scenario: Configure Varnish as http cache
-    Given I set configuration to "ezplatform.http_cache"
+    Given I set configuration to "ezpublish.http_cache"
     """
         purge_type: 'http'
     """


### PR DESCRIPTION
Travis failure: https://travis-ci.org/ezsystems/ezplatform/jobs/626869956?utm_medium=notification&utm_source=slack

In 3.0 we've changed the main config key from `ezpublish` to `ezplatform`. This change can be forward-compatible (https://github.com/ezsystems/ezplatform-core/pull/11), but it requires enabling EzPlatformCoreBundle in AppKernel (`new EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle(),`).

This bundle is not enabled by default (see: https://github.com/ezsystems/ezplatform/blob/2.5/app/AppKernel.php), meaning we cannot use that and have to use `ezpublish` key.

Also changing how the examples are run (they should be run in standard mode, not parallel).