### PR TITLE
EZP-31311: Add missing fieldtype tests

### DIFF
--- a/API/ContentData/ContentDataProvider.php
+++ b/API/ContentData/ContentDataProvider.php
@@ -49,7 +49,7 @@ class ContentDataProvider
         $fieldDefinitions = $contentType->getFieldDefinitions();
 
         foreach ($fieldDefinitions as $field) {
-            $fieldData = $this->getRandomFieldData($field->fieldTypeIdentifier, $language);
+            $fieldData = $this->getRandomFieldData($this->contentTypeIdentifier, $field->identifier, $field->fieldTypeIdentifier, $language);
             $contentCreateStruct->setField($field->identifier, $fieldData, $language);
         }
 
@@ -77,11 +77,11 @@ class ContentDataProvider
         return $contentStruct;
     }
 
-    public function getRandomFieldData($fieldIdentifier, $language = 'eng-GB')
+    public function getRandomFieldData(string $contentTypeIdentifier, string $fieldIdentifier, string $fieldTypeIdentifier, $language = 'eng-GB')
     {
         foreach ($this->fieldTypeDataProviders as $provider) {
-            if ($provider->supports($fieldIdentifier)) {
-                return $provider->generateData($language);
+            if ($provider->supports($fieldTypeIdentifier)) {
+                return $provider->generateData($contentTypeIdentifier, $fieldIdentifier, $language);
             }
         }
     }

--- a/API/ContentData/FieldTypeData/AuthorDataProvider.php
+++ b/API/ContentData/FieldTypeData/AuthorDataProvider.php
@@ -16,7 +16,7 @@ class AuthorDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezauthor';
     }
 
-    public function generateData(string $language = 'eng-GB'): Value
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): Value
     {
         return new Value([$this->getSingleAuthor($language), $this->getSingleAuthor($language)]);
     }

--- a/API/ContentData/FieldTypeData/BinaryFileDataProvider.php
+++ b/API/ContentData/FieldTypeData/BinaryFileDataProvider.php
@@ -16,12 +16,19 @@ class BinaryFileDataProvider implements FieldTypeDataProviderInterface
     ];
     private const FILES_PATH = '../../../Data/Files';
 
+    private $projectDir;
+
+    public function __construct($projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
     public function supports(string $fieldTypeIdentifier): bool
     {
         return $fieldTypeIdentifier === 'ezbinaryfile';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         $filename = self::FILES[array_rand(self::FILES, 1)];
         $filePath = sprintf('%s/%s/%s', __DIR__, self::FILES_PATH, $filename);
@@ -31,6 +38,8 @@ class BinaryFileDataProvider implements FieldTypeDataProviderInterface
 
     public function parseFromString(string $value)
     {
-        return new Value(['inputUri' => $value]);
+        $filePath = sprintf('%s/%s', $this->projectDir, $value);
+
+        return new Value(['inputUri' => $filePath]);
     }
 }

--- a/API/ContentData/FieldTypeData/BooleanDataProvider.php
+++ b/API/ContentData/FieldTypeData/BooleanDataProvider.php
@@ -6,17 +6,34 @@
  */
 namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
 
-class BooleanDataProvider implements FieldTypeDataProviderInterface
+use eZ\Publish\API\Repository\ContentTypeService;
+use EzSystems\BehatBundle\API\ContentData\RandomDataGenerator;
+
+class BooleanDataProvider extends AbstractFieldTypeDataProvider
 {
+    /** @var ContentTypeService */
+    private $contentTypeService;
+
+    public function __construct(RandomDataGenerator $randomDataGenerator, ContentTypeService $contentTypeService)
+    {
+        parent::__construct($randomDataGenerator);
+        $this->contentTypeService = $contentTypeService;
+    }
+
     public function supports(string $fieldTypeIdentifier): bool
     {
         return $fieldTypeIdentifier === 'ezboolean';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
-        // if the field is required then the value has to be true.
-        return true;
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        if ($contentType->getFieldDefinition($fieldIdentifier)->isRequired) {
+            // if the field is required then the value has to be true.
+            return true;
+        }
+
+        return $this->getFaker()->boolean;
     }
 
     public function parseFromString(string $value)

--- a/API/ContentData/FieldTypeData/CountryDataProvider.php
+++ b/API/ContentData/FieldTypeData/CountryDataProvider.php
@@ -30,7 +30,7 @@ class CountryDataProvider implements FieldTypeDataProviderInterface
         return $fieldTypeIdentifier === 'ezcountry';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         $randomCountry = array_rand(self::COUNTRY_DATA, 1);
 

--- a/API/ContentData/FieldTypeData/DateDataProvider.php
+++ b/API/ContentData/FieldTypeData/DateDataProvider.php
@@ -16,7 +16,7 @@ class DateDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezdate';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return new Value($this->getFaker()->dateTimeThisCentury());
     }

--- a/API/ContentData/FieldTypeData/DateTimeDataProvider.php
+++ b/API/ContentData/FieldTypeData/DateTimeDataProvider.php
@@ -16,7 +16,7 @@ class DateTimeDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezdatetime';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return new Value($this->getFaker()->dateTimeThisCentury());
     }

--- a/API/ContentData/FieldTypeData/EmailDataProvider.php
+++ b/API/ContentData/FieldTypeData/EmailDataProvider.php
@@ -13,7 +13,7 @@ class EmailDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezemail' || $fieldTypeIdentifier === 'email';
     }
 
-    public function generateData(string $language = 'eng-GB'): string
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): string
     {
         $this->setLanguage($language);
 

--- a/API/ContentData/FieldTypeData/FieldTypeDataProviderInterface.php
+++ b/API/ContentData/FieldTypeData/FieldTypeDataProviderInterface.php
@@ -12,7 +12,7 @@ interface FieldTypeDataProviderInterface
 
     public function supports(string $fieldTypeIdentifier): bool;
 
-    public function generateData(string $language = 'eng-GB');
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB');
 
     public function parseFromString(string $value);
 }

--- a/API/ContentData/FieldTypeData/FloatDataProvider.php
+++ b/API/ContentData/FieldTypeData/FloatDataProvider.php
@@ -13,7 +13,7 @@ class FloatDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezfloat';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return $this->getFaker()->randomFloat(4);
     }

--- a/API/ContentData/FieldTypeData/ISBNDataProvider.php
+++ b/API/ContentData/FieldTypeData/ISBNDataProvider.php
@@ -13,7 +13,7 @@ class ISBNDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezisbn';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return $this->getFaker()->isbn13;
     }

--- a/API/ContentData/FieldTypeData/ImageAssetDataProvider.php
+++ b/API/ContentData/FieldTypeData/ImageAssetDataProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
+use eZ\Publish\Core\FieldType\ImageAsset\Value;
+use EzSystems\BehatBundle\API\ContentData\RandomDataGenerator;
+use EzSystems\BehatBundle\Helper\ArgumentParser;
+
+class ImageAssetDataProvider extends AbstractFieldTypeDataProvider
+{
+    /**
+     * @var AssetMapper
+     */
+    private $assetMapper;
+    /**
+     * @var ImageDataProvider
+     */
+    private $imageDataProvider;
+
+    private $mappings;
+    /**
+     * @var ArgumentParser
+     */
+    private $argumentParser;
+    /**
+     * @var LocationService
+     */
+    private $locationService;
+    /**
+     * @var URLAliasService
+     */
+    private $urlAliasService;
+
+    public function __construct(RandomDataGenerator $randomDataGenerator,
+                                AssetMapper $assetMapper,
+                                ImageDataProvider $imageDataProvider,
+                                ArgumentParser $argumentParser,
+                                LocationService $locationService,
+                                URLAliasService $urlAliasService,
+                                $mappings)
+    {
+        parent::__construct($randomDataGenerator);
+        $this->assetMapper = $assetMapper;
+        $this->imageDataProvider = $imageDataProvider;
+        $this->argumentParser = $argumentParser;
+        $this->locationService = $locationService;
+        $this->urlAliasService = $urlAliasService;
+        $this->mappings = $mappings;
+    }
+
+    public function supports(string $fieldTypeIdentifier): bool
+    {
+        return $fieldTypeIdentifier === 'ezimageasset';
+    }
+
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
+    {
+        $this->setLanguage($language);
+
+        $imageAssetContentTypeIdentifier = $this->mappings['content_type_identifier'];
+        $imageAssetFieldIdentifier = $this->assetMapper->getContentFieldIdentifier();
+
+        $imageAssetName = $this->getFaker()->realText(80, 1);
+        $imageValue = $this->imageDataProvider->generateData($imageAssetContentTypeIdentifier, $imageAssetFieldIdentifier, $language);
+
+        $content = $this->assetMapper->createAsset($imageAssetName, $imageValue, $language);
+
+        $altText = $this->getFaker()->sentence;
+
+        return new Value($content->getVersionInfo()->getContentInfo()->id, $altText);
+    }
+
+    public function parseFromString(string $value)
+    {
+        $locationURL = $this->argumentParser->parseUrl($value);
+        $urlAlias = $this->urlAliasService->lookup($locationURL);
+
+        $location = $this->locationService->loadLocation($urlAlias->destination);
+
+        return new Value($location->getContentInfo()->id, $this->getFaker()->realText(100));
+    }
+}

--- a/API/ContentData/FieldTypeData/ImageDataProvider.php
+++ b/API/ContentData/FieldTypeData/ImageDataProvider.php
@@ -7,6 +7,7 @@
 namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
 
 use eZ\Publish\Core\FieldType\Image\Value;
+use EzSystems\BehatBundle\API\ContentData\RandomDataGenerator;
 
 class ImageDataProvider extends AbstractFieldTypeDataProvider
 {
@@ -23,12 +24,20 @@ class ImageDataProvider extends AbstractFieldTypeDataProvider
 
     private const IMAGES_PATH = '../../../Data/Images';
 
+    private $projectDir;
+
+    public function __construct(RandomDataGenerator $randomDataGenerator, $projectDir)
+    {
+        parent::__construct($randomDataGenerator);
+        $this->projectDir = $projectDir;
+    }
+
     public function supports(string $fieldTypeIdentifier): bool
     {
         return $fieldTypeIdentifier === 'ezimage';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         $this->setLanguage($language);
 
@@ -47,12 +56,14 @@ class ImageDataProvider extends AbstractFieldTypeDataProvider
 
     public function parseFromString(string $value)
     {
+        $filePath = sprintf('%s/%s', $this->projectDir, $value);
+
         return new Value(
             [
-                'path' => $value,
+                'path' => $filePath,
                 'fileSize' => filesize($value),
                 'fileName' => basename($value),
-                'alternativeText' => $value,
+                'alternativeText' => $this->getFaker()->sentence,
             ]
         );
     }

--- a/API/ContentData/FieldTypeData/IntegerDataProvider.php
+++ b/API/ContentData/FieldTypeData/IntegerDataProvider.php
@@ -13,7 +13,7 @@ class IntegerDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezinteger';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return (int) $this->getFaker()->numerify('########');
     }

--- a/API/ContentData/FieldTypeData/MapDataProvider.php
+++ b/API/ContentData/FieldTypeData/MapDataProvider.php
@@ -38,7 +38,7 @@ class MapDataProvider implements FieldTypeDataProviderInterface
         return $fieldTypeIdentifier === 'ezgmaplocation';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return new Value(self::LOCATION_DATA[array_rand(self::LOCATION_DATA, 1)]);
     }

--- a/API/ContentData/FieldTypeData/MatrixDataProvider.php
+++ b/API/ContentData/FieldTypeData/MatrixDataProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use EzSystems\BehatBundle\API\ContentData\RandomDataGenerator;
+use EzSystems\EzPlatformMatrixFieldtype\FieldType\Value;
+use EzSystems\EzPlatformMatrixFieldtype\FieldType\Value\Row;
+
+class MatrixDataProvider extends AbstractFieldTypeDataProvider
+{
+    private $contentTypeService;
+
+    private const MAX_NUMBER_OF_ITEMS = 200;
+
+    public function __construct(RandomDataGenerator $randomDataGenerator, ContentTypeService $contentTypeService)
+    {
+        parent::__construct($randomDataGenerator);
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    public function supports(string $fieldTypeIdentifier): bool
+    {
+        return $fieldTypeIdentifier === 'ezmatrix';
+    }
+
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
+    {
+        $this->setLanguage($language);
+
+        $fieldDefinition = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier)->getFieldDefinition($fieldIdentifier);
+        $fieldSettings = $fieldDefinition->getFieldSettings();
+
+        $minimumRows = $fieldSettings['minimum_rows'];
+        $columnIdentifiers = array_column($fieldSettings['columns'], 'identifier');
+
+        $numberOfEntriesToCreate = $this->getFaker()->numberBetween($minimumRows, self::MAX_NUMBER_OF_ITEMS);
+
+        $rows = [];
+        for ($i = 0; $i < $numberOfEntriesToCreate; ++$i) {
+            $rows[] = $this->getRandomEntry($columnIdentifiers);
+        }
+
+        return new Value($rows);
+    }
+
+    /**
+     * @param string $value Matrix data. Columns separated by ":" and rows separated by ",". First row is for column indices.
+     * For a 3 column table:
+     * Col1:Col2:col3,value11:value12:value13,value21:value22:value23,value31:value32:value33
+     *
+     * The result would be parsed as:
+     *        Col1    Col2    Col3
+     * Row1: value11 value12 value13
+     * Row2: value21 value22 value23
+     * Row3: value31 value32 value33
+     */
+    public function parseFromString(string $value)
+    {
+        $rows = explode(',', $value);
+
+        $columnIdentifiers = explode(':', array_shift($rows));
+        $numberOfColumns = count($columnIdentifiers);
+
+        $parsedRows = [];
+        foreach ($rows as $row) {
+            $parsedRow = [];
+            $columnValues = explode(':', $row);
+            for ($i = 0; $i < $numberOfColumns; ++$i) {
+                $parsedRow[$columnIdentifiers[$i]] = $columnValues[$i];
+            }
+
+            $parsedRows[] = new Row($parsedRow);
+        }
+
+        return new Value($parsedRows);
+    }
+
+    private function getRandomEntry($columnIdentifiers)
+    {
+        $values = [];
+        foreach ($columnIdentifiers as $columnIdentifier) {
+            $values[$columnIdentifier] = $this->getFaker()->words(3, true);
+        }
+
+        return new Row($values);
+    }
+}

--- a/API/ContentData/FieldTypeData/MediaDataProvider.php
+++ b/API/ContentData/FieldTypeData/MediaDataProvider.php
@@ -17,12 +17,19 @@ class MediaDataProvider implements FieldTypeDataProviderInterface
 
     const VIDEOS_PATH = '../../../Data/Videos';
 
+    private $projectDir;
+
+    public function __construct($projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
     public function supports(string $fieldTypeIdentifier): bool
     {
         return $fieldTypeIdentifier === 'ezmedia';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         $filename = self::VIDEOS[array_rand(self::VIDEOS, 1)];
         $filePath = sprintf('%s/%s/%s', __DIR__, self::VIDEOS_PATH, $filename);
@@ -37,7 +44,8 @@ class MediaDataProvider implements FieldTypeDataProviderInterface
 
     public function parseFromString(string $value)
     {
-        $mediaValue = new Value(['inputUri' => $value]);
+        $filePath = sprintf('%s/%s', $this->projectDir, $value);
+        $mediaValue = new Value(['inputUri' => $filePath]);
         $mediaValue->hasController = true;
         $mediaValue->autoplay = true;
         $mediaValue->loop = true;

--- a/API/ContentData/FieldTypeData/ObjectRelationDataProvider.php
+++ b/API/ContentData/FieldTypeData/ObjectRelationDataProvider.php
@@ -46,7 +46,7 @@ class ObjectRelationDataProvider implements FieldTypeDataProviderInterface
         return $fieldTypeIdentifier === 'ezobjectrelation';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return new Value($this->getRandomContentIds(1));
     }

--- a/API/ContentData/FieldTypeData/ObjectRelationListDataProvider.php
+++ b/API/ContentData/FieldTypeData/ObjectRelationListDataProvider.php
@@ -15,7 +15,7 @@ class ObjectRelationListDataProvider extends ObjectRelationDataProvider
         return $fieldTypeIdentifier === 'ezobjectrelationlist';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return new Value($this->getRandomContentIds(3));
     }

--- a/API/ContentData/FieldTypeData/PasswordProvider.php
+++ b/API/ContentData/FieldTypeData/PasswordProvider.php
@@ -15,7 +15,7 @@ class PasswordProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'password';
     }
 
-    public function generateData(string $language = 'eng-GB'): string
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): string
     {
         return self::DEFAUlT_PASSWORD;
     }

--- a/API/ContentData/FieldTypeData/RichTextDataProvider.php
+++ b/API/ContentData/FieldTypeData/RichTextDataProvider.php
@@ -18,7 +18,7 @@ class RichTextDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezrichtext';
     }
 
-    public function generateData(string $language = 'eng-GB'): string
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): string
     {
         $this->setLanguage($language);
 

--- a/API/ContentData/FieldTypeData/SelectionDataProvider.php
+++ b/API/ContentData/FieldTypeData/SelectionDataProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\Core\FieldType\Selection\Value;
+
+class SelectionDataProvider implements FieldTypeDataProviderInterface
+{
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    public function supports(string $fieldTypeIdentifier): bool
+    {
+        return $fieldTypeIdentifier === 'ezselection';
+    }
+
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
+    {
+        $fieldSettings = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier)->getFieldDefinition($fieldIdentifier)->getFieldSettings();
+
+        $isMultiple = $fieldSettings['isMultiple'];
+        $availableOptions = $fieldSettings['options'];
+
+        $numberOfOptionsToPick = $isMultiple ? random_int(1, count($availableOptions)) : 1;
+        $randomOptionIndices = array_rand(range(0, count($availableOptions) - 1), $numberOfOptionsToPick);
+
+        $randomOptionIndices = is_array($randomOptionIndices) ? $randomOptionIndices : [$randomOptionIndices];
+
+        return new Value($randomOptionIndices);
+    }
+
+    public function parseFromString(string $value)
+    {
+        $options = explode(',', $value);
+
+        return new Value($options);
+    }
+}

--- a/API/ContentData/FieldTypeData/TextBlockDataProvider.php
+++ b/API/ContentData/FieldTypeData/TextBlockDataProvider.php
@@ -6,17 +6,17 @@
  */
 namespace EzSystems\BehatBundle\API\ContentData\FieldTypeData;
 
-class StringDataProvider extends AbstractFieldTypeDataProvider
+class TextBlockDataProvider extends AbstractFieldTypeDataProvider
 {
     public function supports(string $fieldTypeIdentifier): bool
     {
-        return $fieldTypeIdentifier === 'ezstring';
+        return $fieldTypeIdentifier === 'eztext';
     }
 
-    public function generateData(string $language = 'eng-GB'): string
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): string
     {
         $this->setLanguage($language);
 
-        return $this->getFaker()->realText(80, 1);
+        return $this->getFaker()->paragraphs(5, true);
     }
 }

--- a/API/ContentData/FieldTypeData/TextLineDataProvider.php
+++ b/API/ContentData/FieldTypeData/TextLineDataProvider.php
@@ -10,13 +10,13 @@ class TextLineDataProvider extends AbstractFieldTypeDataProvider
 {
     public function supports(string $fieldTypeIdentifier): bool
     {
-        return $fieldTypeIdentifier === 'eztext';
+        return $fieldTypeIdentifier === 'ezstring';
     }
 
-    public function generateData(string $language = 'eng-GB'): string
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB'): string
     {
         $this->setLanguage($language);
 
-        return $this->getFaker()->paragraphs(5, true);
+        return $this->getFaker()->realText(80, 1);
     }
 }

--- a/API/ContentData/FieldTypeData/TimeDataProvider.php
+++ b/API/ContentData/FieldTypeData/TimeDataProvider.php
@@ -16,7 +16,7 @@ class TimeDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'eztime';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return Value::fromDateTime($this->getFaker()->dateTimeThisCentury());
     }

--- a/API/ContentData/FieldTypeData/URLDataProvider.php
+++ b/API/ContentData/FieldTypeData/URLDataProvider.php
@@ -13,7 +13,7 @@ class URLDataProvider extends AbstractFieldTypeDataProvider
         return $fieldTypeIdentifier === 'ezurl';
     }
 
-    public function generateData(string $language = 'eng-GB')
+    public function generateData(string $contentTypeIdentifier, string $fieldIdentifier, string $language = 'eng-GB')
     {
         return $this->getFaker()->url;
     }

--- a/API/Facade/ContentTypeFacade.php
+++ b/API/Facade/ContentTypeFacade.php
@@ -26,6 +26,7 @@ class ContentTypeFacade
         $contentTypeCreateStruct->names = [$mainLanguageCode => $contentTypeName];
         $contentTypeCreateStruct->mainLanguageCode = $mainLanguageCode;
         $contentTypeCreateStruct->isContainer = $isContainer;
+        $contentTypeCreateStruct->nameSchema = $this->getNameSchema($fieldDefinitions);
 
         foreach ($fieldDefinitions as $definition) {
             $contentTypeCreateStruct->addFieldDefinition($definition);
@@ -51,5 +52,12 @@ class ContentTypeFacade
     public function getFieldTypeIdentifierByName(string $fieldtypeName)
     {
         return EzFieldElement::getFieldInternalNameByName($fieldtypeName);
+    }
+
+    private function getNameSchema(array $fieldDefinitions): string
+    {
+        $fieldDefinitionIdentifiers = array_column($fieldDefinitions, 'identifier');
+
+        return sprintf('<%s>', implode('|', $fieldDefinitionIdentifiers));
     }
 }

--- a/API/Facade/UserFacade.php
+++ b/API/Facade/UserFacade.php
@@ -14,8 +14,8 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
-use EzSystems\BehatBundle\API\ContentData\ContentDataProvider;
 use EzSystems\BehatBundle\API\ContentData\FieldTypeData\PasswordProvider;
+use EzSystems\BehatBundle\API\ContentData\RandomDataGenerator;
 
 class UserFacade
 {
@@ -31,20 +31,22 @@ class UserFacade
     /** @var \eZ\Publish\API\Repository\SearchService */
     private $searchService;
 
-    /** @var EzSystems\BehatBundle\API\ContentData\ContentDataProvider */
-    private $contentDataProvider;
+    /**
+     * @var \EzSystems\BehatBundle\API\ContentData\RandomDataGenerator
+     */
+    private $randomDataGenerator;
 
     public const USER_CONTENT_TYPE_IDENTIFIER = 'user';
     public const USERGROUP_CONTENT_IDENTIFIER = 'user_group';
     public const ROOT_USERGROUP_CONTENT_ID = 4;
 
-    public function __construct(UserService $userService, ContentTypeService $contentTypeService, RoleService $roleService, SearchService $searchService, ContentDataProvider $contentDataProvider)
+    public function __construct(UserService $userService, ContentTypeService $contentTypeService, RoleService $roleService, SearchService $searchService, RandomDataGenerator $randomDataGenerator)
     {
         $this->userService = $userService;
         $this->contentTypeService = $contentTypeService;
         $this->roleService = $roleService;
         $this->searchService = $searchService;
-        $this->contentDataProvider = $contentDataProvider;
+        $this->randomDataGenerator = $randomDataGenerator;
     }
 
     public function createUserGroup(string $groupName)
@@ -63,7 +65,7 @@ class UserFacade
     {
         $userCreateStruct = $this->userService->newUserCreateStruct(
             $userName,
-            $this->contentDataProvider->getRandomFieldData('email', $languageCode),
+            $this->randomDataGenerator->getFaker()->email,
             $this->getDefaultPassword(),
             $languageCode,
             $this->contentTypeService->loadContentTypeByIdentifier(self::USER_CONTENT_TYPE_IDENTIFIER));

--- a/Resources/config/services/fieldtype_data_providers.yaml
+++ b/Resources/config/services/fieldtype_data_providers.yaml
@@ -24,9 +24,33 @@ services:
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\AuthorDataProvider: ~
 
-  EzSystems\BehatBundle\API\ContentData\FieldTypeData\BinaryFileDataProvider: ~
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\BinaryFileDataProvider:
+    arguments:
+      $projectDir: '%kernel.project_dir%'
 
-  EzSystems\BehatBundle\API\ContentData\FieldTypeData\BooleanDataProvider: ~
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\BooleanDataProvider:
+    arguments:
+      - '@EzSystems\BehatBundle\API\ContentData\RandomDataGenerator'
+      - '@eZ\Publish\API\Repository\ContentTypeService'
+
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\MatrixDataProvider:
+    arguments:
+      - '@EzSystems\BehatBundle\API\ContentData\RandomDataGenerator'
+      - '@eZ\Publish\API\Repository\ContentTypeService'
+
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\SelectionDataProvider:
+    arguments:
+      - '@eZ\Publish\API\Repository\ContentTypeService'
+
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\ImageAssetDataProvider:
+    arguments:
+      - '@EzSystems\BehatBundle\API\ContentData\RandomDataGenerator'
+      - '@eZ\Publish\Core\FieldType\ImageAsset\AssetMapper'
+      - '@EzSystems\BehatBundle\API\ContentData\FieldTypeData\ImageDataProvider'
+      - '@EzSystems\BehatBundle\Helper\ArgumentParser'
+      - '@eZ\Publish\API\Repository\LocationService'
+      - '@eZ\Publish\API\Repository\URLAliasService'
+      - '$fieldtypes.ezimageasset.mappings$'
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\CountryDataProvider: ~
 
@@ -40,21 +64,25 @@ services:
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\ISBNDataProvider: ~
 
-  EzSystems\BehatBundle\API\ContentData\FieldTypeData\ImageDataProvider: ~
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\ImageDataProvider:
+    arguments:
+      $projectDir: '%kernel.project_dir%'
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\IntegerDataProvider: ~
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\MapDataProvider: ~
 
-  EzSystems\BehatBundle\API\ContentData\FieldTypeData\MediaDataProvider: ~
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\MediaDataProvider:
+    arguments:
+      $projectDir: '%kernel.project_dir%'
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\PasswordProvider: ~
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\RichTextDataProvider: ~
 
-  EzSystems\BehatBundle\API\ContentData\FieldTypeData\StringDataProvider: ~
-
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\TextLineDataProvider: ~
+
+  EzSystems\BehatBundle\API\ContentData\FieldTypeData\TextBlockDataProvider: ~
 
   EzSystems\BehatBundle\API\ContentData\FieldTypeData\TimeDataProvider: ~
 

--- a/features/examples/content.feature
+++ b/features/examples/content.feature
@@ -4,43 +4,46 @@ Feature: Example scenarios showing how to use steps involving Languages, Content
   Scenario Outline: Create a language, Content Type and Content Items
     Given Language "Polski" with code "pol-PL" exists
     And I create a "<contentTypeName>" Content Type in "Content" with "<contentTypeIdentifier>" identifier
-      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable |
-      | Text line   | Name         | name	           | yes      | yes	       | yes          |
-      | <fieldType> | TestedField  | testedfield       | yes      | no	       | yes          |
+      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable | Settings        |
+      | Text line   | Name         | name	           | yes      | yes	       | yes          |                 |
+      | <fieldType> | TestedField  | testedfield       | yes      | no	       | yes          | <fieldSettings> |
     And I create "Folder" Content items in root in "pol-PL"
       | name              | short_name          |
       | <contentTypeName> | <contentTypeName>   |
     And I create 50 "<contentTypeIdentifier>" Content items in "<contentTypeName>" in "pol-PL"
 
     Examples:
-      | contentTypeName      | contentTypeIdentifier | fieldType                    |
-      | RichText CT          | RichTextCT            | Rich text                    |
-      | URL CT               | URLCT                 | URL                          |
-      | Email CT             | EmailCT               | Email address                |
-      | Textline CT          | TextlineCT            | Text line                    |
-      | ISBN CT              | IsbnCT                | ISBN                         |
-      | Authors CT           | AuthorsCT             | Authors                      |
-      | Text block CT        | TextBlockCT           | Text block                   |
-      | Checkbox CT          | CheckboxCT            | Checkbox                     |
-      | Country CT           | CountryCT             | Country                      |
-      | Date CT              | DateCT                | Date                         |
-      | Time CT              | TimeCT                | Time                         |
-      | Float CT             | FloatCT               | Float                        |
-      | Integer CT           | Integer               | Integer                      |
-      | Map location CT      | MapLocationCT         | Map location                 |
-      | Date and time CT     | DateAndTimeCT         | Date and time                |
-      | Content relation CT  | ContentRelationCT     | Content relation (single)    |
-      | Content relations CT | ContentRelationsCT    | Content relations (multiple) |
-      | Image CT             | ImageCT               | Image                        |
-      | File CT              | FileCT                | File                         |
-      | Media CT             | MediaCT               | Media                        |
+      | contentTypeName      | contentTypeIdentifier | fieldType                    | fieldSettings                                                         |
+      | RichText CT          | RichTextCT            | Rich text                    |                                                                       |
+      | URL CT               | URLCT                 | URL                          |                                                                       |
+      | Email CT             | EmailCT               | Email address                |                                                                       |
+      | Textline CT          | TextlineCT            | Text line                    |                                                                       |
+      | ISBN CT              | IsbnCT                | ISBN                         |                                                                       |
+      | Authors CT           | AuthorsCT             | Authors                      |                                                                       |
+      | Text block CT        | TextBlockCT           | Text block                   |                                                                       |
+      | Checkbox CT          | CheckboxCT            | Checkbox                     |                                                                       |
+      | Country CT           | CountryCT             | Country                      |                                                                       |
+      | Date CT              | DateCT                | Date                         |                                                                       |
+      | Time CT              | TimeCT                | Time                         |                                                                       |
+      | Float CT             | FloatCT               | Float                        |                                                                       |
+      | Integer CT           | Integer               | Integer                      |                                                                       |
+      | Map location CT      | MapLocationCT         | Map location                 |                                                                       |
+      | Date and time CT     | DateAndTimeCT         | Date and time                |                                                                       |
+      | Content relation CT  | ContentRelationCT     | Content relation (single)    |                                                                       |
+      | Content relations CT | ContentRelationsCT    | Content relations (multiple) |                                                                       |
+      | Image CT             | ImageCT               | Image                        |                                                                       |
+      | File CT              | FileCT                | File                         |                                                                       |
+      | Media CT             | MediaCT               | Media                        |                                                                       |
+      | Matrix CT            | MatrixCT              | Matrix                       | Min_rows:5,Columns:col1-col2-col3                                     |
+      | Selection CT         | SelectionCT           | Selection                    | is_multiple:false,options:A first-Bielefeld-TestValue-Turtles-Zombies |
+      | ImageAsset CT        | ImageAssetCT          | Image Asset                  |                                                                       |
 
   @admin
   Scenario Outline: Create a Content item and edit specified field
     Given I create a "<contentTypeName>" Content Type in "Content" with "<contentTypeIdentifier>" identifier
-      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable |
-      | Text line   | Name         | name	           | yes      | yes	       | yes          |
-      | <fieldType> | TestedField  | testedfield       | yes      | no	       | yes          |
+      | Field Type  | Name         | Identifier        | Required | Searchable | Translatable | Settings        |
+      | Text line   | Name         | name	           | yes      | yes	       | yes          |                 |
+      | <fieldType> | TestedField  | testedfield       | yes      | no	       | yes          | <fieldSettings> |
     And I create <contentTypeIdentifier> Content items in root in "eng-GB"
       | name              |
       | <contentTypeName> |
@@ -48,29 +51,35 @@ Feature: Example scenarios showing how to use steps involving Languages, Content
       | name              | short_name      |
       | RelationFolder1   | RelationFolder1 |
       | RelationFolder2   | RelationFolder2 |
+    And I create "Image" Content items in "/Media/Images" in "eng-GB"
+      | name               |
+      | ImageForImageAsset |
     When I edit "<contentTypeName>" Content item in "eng-GB"
       | testedfield  |
       | <valueToSet> |
 
     Examples:
-      | contentTypeName       | contentTypeIdentifier | fieldType                    | valueToSet                                                                         |
-      | RichText CT2          | RichTextCT2           | Rich text                    | EditedField                                                                        |
-      | URL CT2               | URLCT2                | URL                          | www.ez.no                                                                          |
-      | Email CT2             | EmailCT2              | Email address                | nospam@ez.no                                                                       |
-      | Textline CT2          | TextlineCT2           | Text line                    | TestTextLine                                                                       |
-      | ISBN CT2              | IsbnCT2               | ISBN                         | 9783161484100                                                                      |
-      | Authors CT2           | AuthorsCT2            | Authors                      | AuthorName,nospam@ez.no                                                            |
-      | Text block CT2        | TextBlockCT2          | Text block                   | TestTextBlock                                                                      |
-      | Checkbox CT2          | CheckboxCT2           | Checkbox                     | true                                                                               |
-      | Country CT2           | CountryCT2            | Country                      | FR                                                                                 |
-      | Date CT2              | DateCT2               | Date                         | 2018-12-31                                                                         |
-      | Time CT2              | TimeCT2               | Time                         | 13:55:00                                                                           |
-      | Float CT2             | FloatCT2              | Float                        | 2.34                                                                               |
-      | Integer CT2           | Integer2              | Integer                      | 10                                                                                 |
-      | Map location CT2      | MapLocationCT2        | Map location                 | Tokio                                                                              |
-      | Date and time CT2     | DateAndTimeCT2        | Date and time                | 2018-12-31 13:55:00                                                                |
-      | Content relation CT2  | ContentRelationCT2    | Content relation (single)    | /RelationFolder1                                                                   |
-      | Content relations CT2 | ContentRelationsCT2   | Content relations (multiple) | RelationFolder1,/RelationFolder2                                                   |
-      | Image CT2             | ImageCT2              | Image                        | /var/www/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Images/small1.jpg |
-      | File CT2              | FileCT2               | File                         | /var/www/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Files/file1.txt   |
-      | Media CT2             | MediaCT2              | Media                        | /var/www/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Videos/video1.mp4 |
+      | contentTypeName       | contentTypeIdentifier | fieldType                    | valueToSet                                                                | fieldSettings                                    |
+      | RichText CT2          | RichTextCT2           | Rich text                    | EditedField                                                               |                                                  |
+      | URL CT2               | URLCT2                | URL                          | www.ez.no                                                                 |                                                  |
+      | Email CT2             | EmailCT2              | Email address                | nospam@ez.no                                                              |                                                  |
+      | Textline CT2          | TextlineCT2           | Text line                    | TestTextLine                                                              |                                                  |
+      | ISBN CT2              | IsbnCT2               | ISBN                         | 9783161484100                                                             |                                                  |
+      | Authors CT2           | AuthorsCT2            | Authors                      | AuthorName,nospam@ez.no                                                   |                                                  |
+      | Text block CT2        | TextBlockCT2          | Text block                   | TestTextBlock                                                             |                                                  |
+      | Checkbox CT2          | CheckboxCT2           | Checkbox                     | true                                                                      |                                                  |
+      | Country CT2           | CountryCT2            | Country                      | FR                                                                        |                                                  |
+      | Date CT2              | DateCT2               | Date                         | 2018-12-31                                                                |                                                  |
+      | Time CT2              | TimeCT2               | Time                         | 13:55:00                                                                  |                                                  |
+      | Float CT2             | FloatCT2              | Float                        | 2.34                                                                      |                                                  |
+      | Integer CT2           | Integer2              | Integer                      | 10                                                                        |                                                  |
+      | Map location CT2      | MapLocationCT2        | Map location                 | Tokio                                                                     |                                                  |
+      | Date and time CT2     | DateAndTimeCT2        | Date and time                | 2018-12-31 13:55:00                                                       |                                                  |
+      | Content relation CT2  | ContentRelationCT2    | Content relation (single)    | /RelationFolder1                                                          |                                                  |
+      | Content relations CT2 | ContentRelationsCT2   | Content relations (multiple) | RelationFolder1,/RelationFolder2                                          |                                                  |
+      | Image CT2             | ImageCT2              | Image                        | vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Images/small1.jpg |                                                  |
+      | File CT2              | FileCT2               | File                         | vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Files/file1.txt   |                                                  |
+      | Media CT2             | MediaCT2              | Media                        | vendor/ezsystems/behatbundle/EzSystems/BehatBundle/Data/Videos/video1.mp4 |                                                  |
+      | Matrix CT2            | MatrixCT2             | Matrix                       | col1:col2:col3,Ala:miała:kota,Szpak:dziobał:bociana,Bociana:dziobał:szpak | Min_rows:2,Columns:col1-col2-col3                |
+      | Selection CT2         | SelectionCT2          | Selection                    | 1,2                                                                       | is_multiple:true,options:Option1-Option2-Option3 |
+      | Image Asset CT2       | ImageAssetCT2         | Image Asset                  | /Media/Images/ImageForImageAsset                                          |                                                  |


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31311

In this PR:
1) I had to extend the parameters passed to `getRandomFieldData`, because the data cannot be generated based on fieldtype identifier alone - for some fields (selection, ezmatrix) the data has to be based on a specific field definition (ezmatric: available columns, selection: predefined options).
2) For file-based fieldtypes (Image, Media, Binary, ImageAsset) I've changed the path to the file - previously full path had to be provided, now the path is relative to the root project directory. This makes it possible to run tests both locally and on Travis without changing anything (previously they failed locally by default).
3) Added DataProviders for: ImageAsset, Matrix and Selection
4) Added the possibility to specify Field Type settings when creating a Content Type
5) Added a default naming schema, based on available field types - it looks like this: `<first-field-identifier|second-field-identifier|third-field-identifier>. Required by ezmatrix - The name for Content Item based on Matrix fieldtype is always an empty string, this allows us to have a fallback.

Companion PRs:
https://github.com/ezsystems/ezplatform-page-builder/pull/484
https://github.com/ezsystems/ezplatform-admin-ui/pull/1208

TODO before merging:
- [x] Remove TMP Travis commit
- [x] Squash commits
