### PR TITLE
EZP-31313: Added multirepository setup feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
     - master
     - /^\d+\.\d+$/
 
-matrix:
+jobs:
   include:
     - name: "Code Style Check"
       env: CHECK_CS=1
@@ -66,6 +66,7 @@ install:
 
 before_script:
   - if [ "${SETUP_BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $SETUP_BEHAT_OPTS" ; fi
+  - if [ "${SETUP_BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "composer run post-install-cmd" ; fi
 
 script:
   - if [ "${CHECK_CS}" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating ; fi

--- a/Helper/ConfigurationEditor.php
+++ b/Helper/ConfigurationEditor.php
@@ -43,6 +43,14 @@ class ConfigurationEditor
         return $config;
     }
 
+    public function get($config, string $key)
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $key = $this->parseKey($key);
+
+        return $propertyAccessor->getValue($config, $key);
+    }
+
     private function modifyValue(&$config, string $key, $value, bool $appendToExisting): void
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -62,3 +62,8 @@ setup:
                 - EzSystems\BehatBundle\Context\Api\TestContext
                 - EzSystems\BehatBundle\Context\Object\LanguageContext
                 - EzSystems\BehatBundle\Context\ConfigurationContext
+        multirepository:
+            paths:
+                - '%paths.base%/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/features/setup/multirepository'
+            contexts:
+                - EzSystems\BehatBundle\Context\ConfigurationContext

--- a/bin/.travis/prepare_multirepository_setup.sh
+++ b/bin/.travis/prepare_multirepository_setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd "$HOME/build/ezplatform";
+
+# Drop database used by default connection
+docker-compose exec --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+
+# Run setup
+docker-compose exec --user www-data app sh -c "bin/ezbehat --mode=standard --profile=setup --suite=multirepository"
+docker-compose exec --user www-data app sh -c "composer run post-install-cmd"
+
+# Reinstal database using the new repository
+docker-compose exec --user www-data app sh -c "composer ezplatform-install"

--- a/doc/features.md
+++ b/doc/features.md
@@ -26,6 +26,12 @@ Before you start using that you need to inject the [drag-mock script](../Resourc
 
 ## BehatBundle extension
 
+### SiteAccess awareness
+
+With `EzBehatExtension` enabled Behat becomes SiteAccess aware. The SiteAccess used can be specified using `EZPLATFORM_SITEACCESS` environment variable, otherwise the default SiteAccess will be used.
+
+### Injecting services
+
 With `EzBehatExtension` enabled you can inject services into your Context classes using the `@injectService` annotation.
 
 Instead of writing:

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -1,0 +1,28 @@
+Feature: Multirepository setup for testing
+
+    @multirepository
+  Scenario: Set up new repository and make the default one unaccessible
+    Given I add a new database connection called "second_connection"
+    And I append configuration to "doctrine.dbal.connections.default" in "app/config/config.yml"
+      """
+        password: ThisPasswordIsIncorrect
+      """
+    And I set configuration to "ezpublish.repositories.new_repository"
+        """
+                storage:
+                    engine: 'legacy'
+                    connection: second_connection
+                    config: {}
+                search:
+                    connection: second_connection
+        """
+    And I append configuration to "doctrine.dbal.connections.default" in "app/config/config.yml"
+      """
+          password: ThisPasswordIsIncorrect
+      """
+    And I set configuration to "admin_group" siteaccess
+      | key                          | value          |
+      | repository                   | new_repository |
+    And I set configuration to "site" siteaccess
+      | key                          | value          |
+      | repository                   | new_repository |

--- a/tests/Helper/ConfigurationEditorTest.php
+++ b/tests/Helper/ConfigurationEditorTest.php
@@ -257,4 +257,24 @@ class ConfigurationEditorTest extends TestCase
 
         Assert::assertEquals(['testKey' => ['nested' => 1]], $config);
     }
+
+    public function testGetSingleValue()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['initialKey' => 'initialValue'];
+
+        $value = $configurationEditor->get($initialConfig, 'initialKey');
+
+        Assert::assertEquals('initialValue', $value);
+    }
+
+    public function testGetMultipleValues()
+    {
+        $configurationEditor = new ConfigurationEditor();
+        $initialConfig = ['initialKey' => ['initialValue1', 'initialValue2']];
+
+        $value = $configurationEditor->get($initialConfig, 'initialKey');
+
+        Assert::assertEquals(['initialValue1', 'initialValue2'], $value);
+    }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31313

This PR adds a feature that allows us to quickly set up multirepository config. The idea is simple:
1) add a new (valid) database connection
2) break the existing one (default) by setting an invalid password
3) create a new repository with the new connection
4) make all siteaccesses use the new repository

If anything tries to use the default repository the application will break, because the default connection is broken. Configuration after the feature is run:
```
doctrine:
     dbal:
          connections:
               default:
                    driver: '%database_driver%'
                    host: '%database_host%'
                    port: '%database_port%'
                    dbname: '%database_name%'
                    user: '%database_user%'
                    password: ThisPasswordIsIncorrect
                    charset: '%database_charset%'
                    server_version: '%database_version%'
               second_connection:
                    driver: '%database_driver%'
                    host: '%database_host%'
                    port: '%database_port%'
                    dbname: '%database_name%'
                    user: '%database_user%'
                    password: '%database_password%'
                    charset: '%database_charset%'
```
```
     repositories:
          default:
               storage: null
               search:
                    engine: '%search_engine%'
                    connection: default
          new_repository:
               storage:
                    engine: legacy
                    connection: second_connection
                    config: {  }
               search:
                    connection: second_connection
```
```
          admin_group:
               languages:
                    - eng-GB
               content_tree_module:
                    contextual_tree_root_location_ids:
                         - 2
                         - 5
                         - 43
                         - 48
               subtree_paths:
                    content: /1/2/
                    media: /1/43/
               repository: new_repository
          site:
               languages:
                    - eng-GB
               repository: new_repository
```
*Note:*
- ~~pretty sure we won't be able to use BehatBundle API Contexts after the new repository is added, because Behat is not siteaccess-aware => we will have to limit ourselves to browser tests (which is good enough for me).*~~ Solved by https://github.com/ezsystems/ezpublish-kernel/pull/2933
- will need to adjust for master, as the files have changes there.

~~*Field definitions tests might not work because of that.~~

Before merging:
- remove TMP changes and squash commits
- add doc after https://github.com/ezsystems/ezpublish-kernel/pull/2933 is accepted
- if all is accepted - make the default "regression" job in PageBuilder use the mutlirepository setup (prepare a new PR)