### PR TITLE
EZP-31311: Added ContentQuery generation

### DIFF
--- a/features/examples/content.feature
+++ b/features/examples/content.feature
@@ -37,6 +37,7 @@ Feature: Example scenarios showing how to use steps involving Languages, Content
       | Matrix CT            | MatrixCT              | Matrix                       | Min_rows:5,Columns:col1-col2-col3                                     |
       | Selection CT         | SelectionCT           | Selection                    | is_multiple:false,options:A first-Bielefeld-TestValue-Turtles-Zombies |
       | ImageAsset CT        | ImageAssetCT          | Image Asset                  |                                                                       |
+      | ContentQuery CT      | ContentQueryCT        | Content query                | QueryType-EzPlatformAdminUi:MediaSubtree,ContentType-folder           |
 
   @admin
   Scenario Outline: Create a Content item and edit specified field

--- a/src/lib/API/ContentData/FieldTypeNameConverter.php
+++ b/src/lib/API/ContentData/FieldTypeNameConverter.php
@@ -11,6 +11,7 @@ class FieldTypeNameConverter
     private static $FIELD_TYPE_MAPPING = [
         'ezauthor' => 'Authors',
         'ezboolean' => 'Checkbox',
+        'ezcontentquery' => 'Content query',
         'ezobjectrelation' => 'Content relation (single)',
         'ezobjectrelationlist' => 'Content relations (multiple)',
         'ezcountry' => 'Country',

--- a/src/lib/API/Context/ContentTypeContext.php
+++ b/src/lib/API/Context/ContentTypeContext.php
@@ -74,29 +74,51 @@ class ContentTypeContext implements Context
         $parsedSettings = [];
         // TODO: Clean this up in the future if needed
         switch ($fieldTypeIdentifier) {
+            case 'ezcontentquery':
+                return $this->parseContentQuerySettings($settings);
             case 'ezmatrix':
-                //Example: min_rows:5,Columns:col1-col2-col3
-                $fields = explode(',', $settings);
-                $minRows = (int) explode(':', $fields[0])[1];
-                $parsedSettings['minimum_rows'] = $minRows;
-                $columns = explode('-', explode(':', $fields[1])[1]);
-                foreach ($columns as $column) {
-                    $parsedSettings['columns'][] = ['identifier' => $column, 'name' => $column];
-                }
-
-                return $parsedSettings;
+                return $this->parseMatrixSettings($settings);
             case 'ezselection':
-                // Example: "is_multiple:false,options:Value1-Value2-Value3"
-                $fields = explode(',', $settings);
-                $isMultiple = $this->parseBool(explode(':', $fields[0])[1]);
-                $options = explode(':', $fields[1])[1];
-                $parsedOptions = array_values(explode('-', $options));
-                $parsedSettings['isMultiple'] = $isMultiple;
-                $parsedSettings['options'] = $parsedOptions;
-
-                return $parsedSettings;
+                return $this->parseSelectionSettings($settings);
             default:
                 return $parsedSettings;
         }
+    }
+
+    private function parseMatrixSettings(string $settings): array
+    {
+        //Example: min_rows:5,Columns:col1-col2-col3
+        $fields = explode(',', $settings);
+        $minRows = (int) explode(':', $fields[0])[1];
+        $parsedSettings['minimum_rows'] = $minRows;
+        $columns = explode('-', explode(':', $fields[1])[1]);
+        foreach ($columns as $column) {
+            $parsedSettings['columns'][] = ['identifier' => $column, 'name' => $column];
+        }
+
+        return $parsedSettings;
+    }
+
+    private function parseSelectionSettings(string $settings): array
+    {
+        // Example: "is_multiple:false,options:Value1-Value2-Value3"
+        $fields = explode(',', $settings);
+        $isMultiple = $this->parseBool(explode(':', $fields[0])[1]);
+        $options = explode(':', $fields[1])[1];
+        $parsedOptions = array_values(explode('-', $options));
+        $parsedSettings['isMultiple'] = $isMultiple;
+        $parsedSettings['options'] = $parsedOptions;
+
+        return $parsedSettings;
+    }
+
+    private function parseContentQuerySettings(string $settings): array
+    {
+        // Example: "QueryType-EzPlatformAdminUi:MediaSubtree,ContentType-folder"
+        $fields = explode(',', $settings);
+        $parsedSettings['QueryType'] = explode('-', $fields[0])[1];
+        $parsedSettings['ReturnedType'] = explode('-', $fields[1])[1];
+
+        return $parsedSettings;
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31311

Required by: https://github.com/ezsystems/ezplatform-admin-ui/pull/1228

Adding the possibility to create Content Types with `ezcontentquery` field. Also making sure that it's possible to create Content Items with it using the API.

Fieldtype is not editable, so no scenario that it can be edited.
