### PR TITLE
EZEE-2993: Changed regression script to work with Page Builder PRs as dependency

### DIFF
--- a/bin/.travis/trigger_ci.sh
+++ b/bin/.travis/trigger_ci.sh
@@ -32,13 +32,14 @@ REPOSITORY_URLS=()
 GITHUB_OAUTH_TOKEN=$(composer config github-oauth.github.com --global)
 TARGET_METAREPOSITORY_BRANCH=""
 TARGET_PAGE_BUILDER_BRANCH=""
+HAS_PAGE_BUILDER_DEPENDENCY=0
 
 # Step 1: ask for number of PRs and a link for each PR
 
 read -p 'Number of pull requests: ' numberOfDependencies
 
 for ((n=0;n<$numberOfDependencies;n++)); do
-  read -p 'Pull request link:' link
+  read -p 'Pull request link: ' link
   prLinks+=("$link")
 done
 
@@ -53,9 +54,18 @@ do
 
   BRANCH_NAME="${VALUES[1]}"
   BRANCH_ALIAS="${VALUES[2]}"
-  REPOSITORY="${VALUES[3]}"
+  REPOSITORY_NAME="${VALUES[3]}"
 
-  composerDependencyString=$(printf "ezsystems/%s:dev-%s as %s" $REPOSITORY $BRANCH_NAME $BRANCH_ALIAS)
+  if [ "${REPOSITORY_NAME}" == "ezplatform-page-builder" ] ; then
+    # We need to detect Page Builder because the regression is run by creating a PR in that repo - if there is a PR already we don't need to create a new one
+    HAS_PAGE_BUILDER_DEPENDENCY=1
+    PAGE_BUILDER_PR_BRANCH=$BRANCH_NAME
+  elif [ "${HAS_PAGE_BUILDER_DEPENDENCY}" == 0 ]; then
+    # If Page Builder dependency has been detected for earlier links do not overwrite it
+    PAGE_BUILDER_PR_BRANCH=$CONST_RANDOM_STRING
+  fi
+
+  composerDependencyString=$(printf "ezsystems/%s:dev-%s as %s" $REPOSITORY_NAME $BRANCH_NAME $BRANCH_ALIAS)
   composerDependencyStrings+=("$composerDependencyString")
 
   TARGET_METAREPOSITORY_BRANCH="${VALUES[4]}"
@@ -84,7 +94,7 @@ do
   composer require --no-update --no-progress --no-scripts "$i"
 done
 
-echo 'Dependencies have been added ✔'
+echo -e 'Dependencies have been added \033[0;32m✔\033[0m'
 
 # Step 5: Push the metarepo
 
@@ -95,32 +105,55 @@ git remote add regression-remote http://github.com/mnocon/ezplatform-ee.git
 git push --set-upstream regression-remote $METAREPOSITORY_BRANCH_NAME --quiet > /dev/null
 cd ..
 
-echo 'Prepared a branch with dependencies using ezplatform-ee repository ✔'
+echo -e 'Prepared a branch with dependencies using ezplatform-ee repository \033[0;32m✔\033[0m'
 
-## Step 6: Trigger a build in Page Builder using a Pull Request
+## Step 6: Clone Page Builder repository
 
-git clone --quiet http://github.com/ezsystems/ezplatform-page-builder.git -b $TARGET_PAGE_BUILDER_BRANCH --quiet
-cd ezplatform-page-builder
-git checkout -b $CONST_RANDOM_STRING --quiet || exit 1
-git branch -D $TARGET_PAGE_BUILDER_BRANCH --quiet || exit 1
+if [ "${HAS_PAGE_BUILDER_DEPENDENCY}" == 1 ] ; then
+  # If there is a Page Builder dependency then we need to add a commit there, not to a new branch
+  git clone --quiet http://github.com/ezsystems/ezplatform-page-builder.git -b $PAGE_BUILDER_PR_BRANCH
+  cd ezplatform-page-builder
+else
+  # Without an existing Page Builder branch we base a new branch on the target branch
+  git clone --quiet http://github.com/ezsystems/ezplatform-page-builder.git -b $TARGET_PAGE_BUILDER_BRANCH
+  cd ezplatform-page-builder
+  git checkout -b $PAGE_BUILDER_PR_BRANCH --quiet || exit 1
+  git branch -D $TARGET_PAGE_BUILDER_BRANCH --quiet || exit 1
+fi
+
+# Step 7: Prepare a commit in Page Builder
+
 sed -i '' -e 's/https:\/\/github.com\/ezsystems\/ezplatform-ee.git/https:\/\/github.com\/mnocon\/ezplatform-ee.git/g' .travis.yml
 composer config extra._ezplatform_branch_for_behat_tests $METAREPOSITORY_BRANCH_NAME
 git add composer.json .travis.yml
-git commit -m "Run regression" --quiet
+git commit -m "[TMP] Run regression" --quiet
 
-# Step 7: Create a Pull Request and open it
-printf "About to push in Page Builder to branch %s\n" "$(git rev-parse --abbrev-ref HEAD)"
+# Step 8: Push to Page Builder. Open existing PR or create a new one
+printf "About to push in Page Builder to branch \033[1;32m%s\033[0m\n" "$(git rev-parse --abbrev-ref HEAD)"
+if [ "${HAS_PAGE_BUILDER_DEPENDENCY}" == 1 ] ; then
+  echo -e "\033[1;33mThis is an existing branch that contains work done by someone else.\033[0m"
+  echo -e "\033[1;33mRemember to talk with them that you are adding a commit to their branch and clearly mark the Pull Request as one containing temporary changes.\033[0m"
+fi
 read -p "Do you want to continue? " -n 1 -r
 echo ''
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-  git push --set-upstream origin $CONST_RANDOM_STRING --quiet  > /dev/null
-  echo 'Prepared a branch in Page Builder repository ✔'
 
-  hub pull-request -b $TARGET_PAGE_BUILDER_BRANCH -m "[DON'T MERGE] Running regression tests" -m "Add your description here." -l "Work in progress" --browse
-  echo 'Prepared a Pull Request in Page Builder triggering the build ✔'
-  exit 0
+if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
+  printf 'Aborted.\n'
+  exit 1
 fi
 
-printf 'Aborted.\n'
-exit 1
+# Push to Page Builder
+git push --set-upstream origin $PAGE_BUILDER_PR_BRANCH --quiet  > /dev/null
+echo -e 'Pushed to Page Builder repository \033[0;32m✔\033[0m'
+
+if [ "${HAS_PAGE_BUILDER_DEPENDENCY}" == 1 ] ; then
+  # Open existing PR
+  echo -e '\033[1;33mOpening existing Pull Request. Remember to indicate that it contains temporary commit.\033[0m'
+  hub pr show
+else
+  # Without an existing Page Builder branch we need to create a new PR
+  hub pull-request -b $TARGET_PAGE_BUILDER_BRANCH -m "[DON'T MERGE] Running regression tests" -m "Add your description here." -l "Work in progress" --browse
+  echo -e 'Prepared a Pull Request in Page Builder triggering the build \033[0;32m✔\033[0m'
+fi
+
+echo -e 'Script finished \033[0;32m✔\033[0m'

--- a/bin/.travis/trigger_ci.sh
+++ b/bin/.travis/trigger_ci.sh
@@ -138,7 +138,7 @@ read -p "Do you want to continue? " -n 1 -r
 echo ''
 
 if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
-  printf 'Aborted.\n'
+  echo -e '\033[0;31mAborted.\033[0m'
   exit 1
 fi
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZEE-2993

This PR reworks the script so that is works for Pull Requests to Page Builder repository.

There are two scenarios now:
1) there is no Page Builder dependency among given links: the script will create a branch and Pull Request in Page Builder
2) there is a Page Builder dependency among given links: the script will push a TMP commit to an existing branch

Other things:
1) Added colors 🎉 and improved some text formatting
2) Changed the commit message to `[TMP] Run regression` - it still runs the regression builds but can be easier detected and dropped when rebasing a PR