### PR TITLE
EZP-31441: Handle undefined target metarepository branch

### DIFF
--- a/Command/GetPullRequestDataCommand.php
+++ b/Command/GetPullRequestDataCommand.php
@@ -25,6 +25,8 @@ class GetPullRequestDataCommand extends Command
     /** @var \Http\Client\HttpClient */
     private $httpClient;
 
+    private const UNDEFINED_VALUE = 'undefined';
+
     public function __construct()
     {
         parent::__construct();
@@ -87,8 +89,9 @@ If you have configured Composer with your token it can be obtained by running 'c
             $branchName,
             $branchAlias,
             $prUrlData['repository'],
-            $metarepositoryBranch,
-            $pageBuilderBranch);
+            $metarepositoryBranch ?: self::UNDEFINED_VALUE,
+            $pageBuilderBranch ?: self::UNDEFINED_VALUE
+        );
 
         $output->write($outputString);
     }
@@ -143,8 +146,12 @@ If you have configured Composer with your token it can be obtained by running 'c
             'master' => 'master',
         ];
 
+        if ($metarepositoryTargetBranch === '') {
+            return '';
+        }
+
         if (!array_key_exists($metarepositoryTargetBranch, $pageBuilderTargetBranches)) {
-            throw new \Exception(sprintf('Cannot find suitable PageBuilder branch for %s metareposiotry branch', $metarepositoryTargetBranch));
+            throw new \Exception(sprintf('Cannot find suitable PageBuilder branch for %s metarepository branch', $metarepositoryTargetBranch));
         }
 
         return $pageBuilderTargetBranches[$metarepositoryTargetBranch];

--- a/bin/.travis/trigger_ci.sh
+++ b/bin/.travis/trigger_ci.sh
@@ -33,6 +33,7 @@ GITHUB_OAUTH_TOKEN=$(composer config github-oauth.github.com --global)
 TARGET_METAREPOSITORY_BRANCH=""
 TARGET_PAGE_BUILDER_BRANCH=""
 HAS_PAGE_BUILDER_DEPENDENCY=0
+UNDEFINED_VALUE="undefined"
 
 # Step 1: ask for number of PRs and a link for each PR
 
@@ -68,9 +69,22 @@ do
   composerDependencyString=$(printf "ezsystems/%s:dev-%s as %s" $REPOSITORY_NAME $BRANCH_NAME $BRANCH_ALIAS)
   composerDependencyStrings+=("$composerDependencyString")
 
-  TARGET_METAREPOSITORY_BRANCH="${VALUES[4]}"
-  TARGET_PAGE_BUILDER_BRANCH="${VALUES[5]}"
+  PARSED_PR_METAREPOSITORY_BRANCH="${VALUES[4]}"
+  PARSED_PR_PAGE_BUILDER_BRANCH="${VALUES[5]}"
+
+  if [ "${PARSED_PR_METAREPOSITORY_BRANCH}" != "${UNDEFINED_VALUE}" ] ; then
+      TARGET_METAREPOSITORY_BRANCH=$PARSED_PR_METAREPOSITORY_BRANCH
+  fi
+
+  if [ "${PARSED_PR_PAGE_BUILDER_BRANCH}" != "${UNDEFINED_VALUE}" ] ; then
+      TARGET_PAGE_BUILDER_BRANCH=$PARSED_PR_PAGE_BUILDER_BRANCH
+  fi
 done
+
+if [ "${TARGET_METAREPOSITORY_BRANCH}" == "" ] || [ "${TARGET_PAGE_BUILDER_BRANCH}" == "" ] ; then
+    echo 'Could not determine target metarepository or Page Builder branch. Aborting.'
+    exit 1
+fi
 
 # Step 3: Prepare ezplatfom-ee repository
 rm -rf regression_setup


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31441

~~Will have to be rebased after https://github.com/ezsystems/BehatBundle/pull/131 is merged~~

Currently the script tries to read "_ezplatform_branch_for_behat_tests" for all repositories given, but it's not defined everywhere (for example in solr bundle). This causes the script to fail, as it cannot determine the metarepository branch for given PR.

This PR changes that - it's enough that at least one PR has Behat setup, so that the script can take data from that.*

*That means that it's still not possible to run regression for a single PR that has no Behat setup, but we need to tackle that in another issue, as it's not very likely.