### PR TITLE
Changed sed usage to make regression script crossplatform

### DIFF
--- a/bin/.travis/trigger_ci.sh
+++ b/bin/.travis/trigger_ci.sh
@@ -123,7 +123,7 @@ fi
 
 # Step 7: Prepare a commit in Page Builder
 
-sed -i '' -e 's/https:\/\/github.com\/ezsystems\/ezplatform-ee.git/https:\/\/github.com\/mnocon\/ezplatform-ee.git/g' .travis.yml
+sed -i.bak -e 's/https:\/\/github.com\/ezsystems\/ezplatform-ee.git/https:\/\/github.com\/mnocon\/ezplatform-ee.git/g' .travis.yml
 composer config extra._ezplatform_branch_for_behat_tests $METAREPOSITORY_BRANCH_NAME
 git add composer.json .travis.yml
 git commit -m "[TMP] Run regression" --quiet


### PR DESCRIPTION
`sed` program is different on Linux and OSX and there are some platform differences. One of them is the `-i` option, which causes the current script to fail on Linux.

Behaviour (described in comment on StackOverflow linked below):
```
This works with GNU sed, but not on OS X:

sed -i -e 's/foo/bar/' target.file
sed -i'' -e 's/foo/bar/' target.file

This works on OS X, but not with GNU sed:

sed -i '' -e 's/foo/bar/' target.file
```

Changing to solution suggested in https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux . This created a backup file, but the file is created in a tmp directory so I don't consider it an issue.

Thanks to @katarzynazawada for discovering it!
