### PR TITLE
Changed sorting order in listing Features for fastest

### DIFF
--- a/bin/ezbehat
+++ b/bin/ezbehat
@@ -54,10 +54,9 @@ fastest(){
 # Fastest option 'list-features' gives us the list of all features from given context in random order, which are later
 # run in this order in few threads and dynamically distributed between these threads. That gives us different test build
 # times each build, often non optimal. To make this optimal we sort features by the number of scenarios in them
-# (ascending because Fastest reverse the queue order, and we want this queue to run descending) and run them in that order,
-# to minimize final time gap between the threads.
+# (descending) and run them in that order, to minimize final time gap between the threads.
 get_behat_features(){
-    bin/behat ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort | awk '{ print $2 }'
+    bin/behat ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
 }
 
 for i in "$@"


### PR DESCRIPTION
If you look at the features run in https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/299676714#L1312-L1334 you can see that they are in wrong order:
```
1/23	✔	55 s 310 ms	/var/www/vendor/ezsystems/date-based-publisher/Features/PublishInTheFuture.feature
2/23	✔	6 s 515 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/Authentication.feature
3/23	✔	1 min 45 s 313 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/SystemInfo.feature
4/23	✔	3 min 7 s 243 ms	/var/www/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Collection.feature
5/23	✔	1 min 50 s 698 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentCreation.feature
6/23	✔	1 min 31 s 147 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentType.feature
7/23	✔	1 min 54 s 313 ms	/var/www/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/ContentIntegration.feature
8/23	✔	5 min 58 s 706 ms	/var/www/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/ContentScheduler.feature
9/23	✔	1 min 23 s 782 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentTypeGroup.feature
10/23	✔	4 min 17 s 800 ms	/var/www/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/PageBuilderActions.feature
11/23	✔	1 min 31 s 507 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/Languages.feature
12/23	✔	6 min 8 s 124 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentManagement.feature
13/23	✔	4 min 13 s 564 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/Trash.feature
14/23	✔	3 min 35 s 939 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentDraft.feature
15/23	✔	2 min 20 s 341 ms	/var/www/vendor/ezsystems/ezplatform-form-builder/features/FormSubmissionsAdministration.feature
16/23	✔	3 min 37 s 795 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/Sections.feature
17/23	✔	5 min 40 s 200 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/Roles.feature
18/23	✔	3 min 34 s 929 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ObjectStates.feature
19/23	✘	11 min 29 s 827 ms	/var/www/vendor/ezsystems/ezplatform-form-builder/features/FormFieldConfiguration.feature
20/23	✔	8 min 33 s 537 ms	/var/www/vendor/ezsystems/ezplatform-form-builder/features/FormContentItemAdministration.feature
21/23	✘	22 min 42 s 948 ms	/var/www/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Blocks.feature
22/23	✘	26 min 48 s 512 ms	/var/www/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentTypeFields.feature
23/23	✔	28 min 51 s 741 ms	/var/www/vendor/ezsystems/ezplatform-form-builder/features/FormBuilderTests.feature
```

This is caused by the the new version of `fastest` (our fork) which fixes this issue: https://github.com/liuggio/fastest/issues/135

We've been working around it so far, now there's no need for that.

Result after the fix:
```
MBP-Marek:v3 mareknocon$ bin/ezbehat -m=get-features -p=regression -s=regression
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-form-builder/features/FormBuilderTests.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentTypeFields.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Blocks.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-form-builder/features/FormContentItemAdministration.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ObjectStates.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/Roles.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-form-builder/features/FormFieldConfiguration.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/Sections.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-form-builder/features/FormSubmissionsAdministration.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentDraft.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/Trash.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/Languages.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentManagement.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/PageBuilderActions.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentTypeGroup.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/ContentIntegration.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentType.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/ContentCreation.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/ContentScheduler.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/SystemInfo.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-admin-ui/features/standard/Authentication.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage/Blocks/Collection.feature
/Users/mareknocon/Desktop/Sites/v3/vendor/ezsystems/date-based-publisher/Features/PublishInTheFuture.feature
```

This is important to fix because the current order of features is the worst for us - the two longest features are run as last, which makes the build a couple of minutes longer.