### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "fzaninotto/faker": "^1.9",
         "guzzlehttp/psr7": "^1.6.1",
         "behat/behat": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "behat/behat": "^3.6",
         "friends-of-behat/mink": "^1.8",
         "behat/mink-selenium2-driver": "^1.4",
-        "friends-of-behat/symfony-extension": "^2.0",
+        "friends-of-behat/symfony-extension": "^2.1@beta",
         "friends-of-behat/mink-extension": "^2.4",
         "php-http/client-common": "^2.1",
         "symfony/property-access": "^5.0",
@@ -28,6 +28,7 @@
         "symfony/console": "^5.0"
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "phpunit/phpunit": "^8.5",

--- a/src/bundle/Command/CreateLanguageCommand.php
+++ b/src/bundle/Command/CreateLanguageCommand.php
@@ -37,7 +37,6 @@ class CreateLanguageCommand extends Command
         parent::__construct(null);
     }
 
-
     protected function configure()
     {
         $this

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -39,7 +39,7 @@ class TestSiteaccessCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln($this->siteaccess->name);
-        
+
         return 0;
     }
 }

--- a/src/lib/API/Context/LimitationParser/LimitationParsersCollector.php
+++ b/src/lib/API/Context/LimitationParser/LimitationParsersCollector.php
@@ -19,7 +19,6 @@ class LimitationParsersCollector
         $this->limitationParsers = $limitationParsers;
     }
 
-
     public function addLimitationParser(LimitationParserInterface $limitationParser): void
     {
         $this->limitationParsers[] = $limitationParser;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | TBD
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation:

- `friends-of-behat/symfony-extension` is required in `2.1@beta` version supporting Symfony5 (no stable release available yet).
- `ezsystems/doctrine-dbal-schema` is required  in `1.0@dev` version due to Composer minimum stability requirements.

#### TODO.
- [ ] Wait for Travis