### PR TITLE
Added site/view permission to SubtreeEditor

### DIFF
--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -24,6 +24,7 @@ Feature: Editor that has access only to a Subtree of Content Structure
     And I create a role "BasicRole" with policies
       | module      | function   |
       | user        | login      |
+      | site        | view       |
     And I create a user "ThisUserIsAReviewer" with last name "Test" in group "SubtreeEditorsGroup"
     And I add policy "content" "read" to "BasicRole" with limitations
       | limitationType      | limitationValue                                    |


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZEE-3090

https://github.com/ezsystems/ezplatform-site-factory/pull/53 adds new permissions and `site/view` is among them - it's required if user wants to see the "Site" tab in upper menu.

Adjusting Subtree Editor permissions so that he can continue accessing it.

This permission won't be available in open source, so it will be useless/ignored in open source version.