### PR TITLE
Adjusted code for PHP7.4

### DIFF
--- a/Context/Object/UserContext.php
+++ b/Context/Object/UserContext.php
@@ -66,7 +66,7 @@ class UserContext implements Context
             throw new \Exception('Passed more than one Role assignment limitation!');
         }
 
-        $roleLimitation = $parsedLimitations[0];
+        $roleLimitation = $parsedLimitations[0] ?? null;
 
         $this->userFacade->assignUserGroupToRole($userGroupName, $roleName, $roleLimitation);
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31542

Current code fails on PHP 7.4, as `$parsedLimitations` can be null:
```
` Notice: Trying to access array offset on value of type null in vendor/ezsystems/behatbundle/src/lib/API/Context/UserContext.php line 65`
```