### PR TITLE
EZP-30465: Fixed PermissionResolver injection into Behat TestContext

### DIFF
--- a/src/bundle/Resources/config/services/contexts.yaml
+++ b/src/bundle/Resources/config/services/contexts.yaml
@@ -35,7 +35,7 @@ services:
         public: true
         arguments:
             $userService: '@ezpublish.api.service.user'
-            $permissionResolver: '@=service("ezpublish.api.repository").getPermissionResolver()'
+            $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
 
     EzSystems\Behat\API\Context\UserContext:
         public: true


### PR DESCRIPTION
Related to [EZP-30465](https://jira.ez.no/browse/EZP-30465) as an intermediate step.

Fixed `PermissionResolver` injection into EzSystems\Behat\API\Context\TestContext (similar case like ezsystems/ezplatform-kernel/#43).

I think if there are no review objections and Behat passes, it should be ok to merge.