### PR TITLE
Adjusted Page Builder branches map for new stable branch

### DIFF
--- a/Command/GetPullRequestDataCommand.php
+++ b/Command/GetPullRequestDataCommand.php
@@ -143,6 +143,7 @@ If you have configured Composer with your token it can be obtained by running 'c
     {
         $pageBuilderTargetBranches = [
             '2.5' => '1.3',
+            '3.0' => '2.0',
             'master' => 'master',
         ];
 


### PR DESCRIPTION
Once we have a metarepository branch on which the tests should run we need to create a PR targeted to corresponding Page Builder branch.

Right now the Page Builder branch is detected using a hardcoded map (not good, we need to refactor it at some point), this PR updates the map for new stable branches.