### PR TITLE
[SPIKE] Volume testing

### DIFF
--- a/API/ContentData/ContentDataProvider.php
+++ b/API/ContentData/ContentDataProvider.php
@@ -8,8 +8,10 @@ namespace EzSystems\BehatBundle\API\ContentData;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentStruct;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\BehatBundle\API\ContentData\FieldTypeData\FieldTypeDataProviderInterface;
 
@@ -43,17 +45,17 @@ class ContentDataProvider
     public function getRandomContentData($language): ContentCreateStruct
     {
         $contentType = $this->contentTypeService->loadContentTypeByIdentifier($this->contentTypeIdentifier);
-
         $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, $language);
 
-        $fieldDefinitions = $contentType->getFieldDefinitions();
+        return $this->fillContentStructWithData($contentType, $language, $contentCreateStruct);
+    }
 
-        foreach ($fieldDefinitions as $field) {
-            $fieldData = $this->getRandomFieldData($this->contentTypeIdentifier, $field->identifier, $field->fieldTypeIdentifier, $language);
-            $contentCreateStruct->setField($field->identifier, $fieldData, $language);
-        }
+    public function getRandomContentUpdateData(string $language): ContentUpdateStruct
+    {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($this->contentTypeIdentifier);
+        $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
 
-        return $contentCreateStruct;
+        return $this->fillContentStructWithData($contentType, $language, $contentUpdateStruct);
     }
 
     public function getFilledContentDataStruct(ContentStruct $contentStruct, $contentItemData, $language): ContentStruct
@@ -72,6 +74,18 @@ class ContentDataProvider
 
             $fieldData = $this->getFieldDataFromString($fieldDefinition[0]->fieldTypeIdentifier, $value);
             $contentStruct->setField($fieldIdentifier, $fieldData, $language);
+        }
+
+        return $contentStruct;
+    }
+
+    private function fillContentStructWithData(ContentType $contentType, string $language, ContentStruct $contentStruct): ContentStruct
+    {
+        $fieldDefinitions = $contentType->getFieldDefinitions();
+
+        foreach ($fieldDefinitions as $field) {
+            $fieldData = $this->getRandomFieldData($this->contentTypeIdentifier, $field->identifier, $field->fieldTypeIdentifier, $language);
+            $contentStruct->setField($field->identifier, $fieldData, $language);
         }
 
         return $contentStruct;

--- a/API/Facade/ContentFacade.php
+++ b/API/Facade/ContentFacade.php
@@ -9,6 +9,7 @@ namespace EzSystems\BehatBundle\API\Facade;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use EzSystems\BehatBundle\API\ContentData\ContentDataProvider;
 use PHPUnit\Framework\Assert;
@@ -35,7 +36,7 @@ class ContentFacade
         $this->contentDataProvider = $contentDataProvider;
     }
 
-    public function createContent($contentTypeIdentifier, $parentUrl, $language, $contentItemData = null)
+    public function createContentDraft($contentTypeIdentifier, $parentUrl, $language, $contentItemData = null): Content
     {
         $parentUrlAlias = $this->urlAliasService->lookup($parentUrl);
         Assert::assertEquals(URLAlias::LOCATION, $parentUrlAlias->type);
@@ -52,7 +53,15 @@ class ContentFacade
         }
 
         $draft = $this->contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
-        $this->contentService->publishVersion($draft->versionInfo);
+
+        return $draft;
+    }
+
+    public function createContent($contentTypeIdentifier, $parentUrl, $language, $contentItemData = null): Content
+    {
+        $draft = $this->createContentDraft($contentTypeIdentifier, $parentUrl, $language, $contentItemData);
+
+        return $this->contentService->publishVersion($draft->versionInfo);
     }
 
     public function editContent($locationURL, $language, $contentItemData)

--- a/API/Facade/SearchFacade.php
+++ b/API/Facade/SearchFacade.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\API\Facade;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
+use eZ\Publish\API\Repository\Values\Content\URLAlias;
+use PHPUnit\Framework\Assert;
+
+class SearchFacade
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\URLAliasService */
+    private $urlAliasService;
+
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    public function __construct(URLAliasService $urlAliasService, LocationService $locationService, SearchService $searchService)
+    {
+        $this->urlAliasService = $urlAliasService;
+        $this->locationService = $locationService;
+        $this->searchService = $searchService;
+    }
+
+    public function getRandomChildFromPath(string $path): string
+    {
+        $urlAlias = $this->urlAliasService->lookup($path);
+        Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
+
+        $location = $this->locationService->loadLocation($urlAlias->destination);
+
+        $query = new LocationQuery();
+        $query->filter = new LogicalAnd([
+            new Subtree($location->pathString),
+            new LogicalNot(new LocationId($location->id)),
+        ]);
+
+        $query->limit = 100;
+
+        $results = $this->searchService->findLocations($query)->searchHits;
+
+        $resultCount = count($results);
+        $randomInt = random_int(0, $resultCount - 1);
+
+        $location = $results[$randomInt]->valueObject;
+
+        return $this->urlAliasService->reverseLookup($location)->path;
+    }
+}

--- a/Command/CreateExampleDataCommand.php
+++ b/Command/CreateExampleDataCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+namespace EzSystems\BehatBundle\Command;
+
+use EzSystems\BehatBundle\Event\TransitionEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class CreateExampleDataCommand extends Command
+{
+    private $eventDispatcher;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(EventDispatcher $eventDispatcher, LoggerInterface $logger)
+    {
+        parent::__construct();
+        $this->stopwatch = new Stopwatch();
+        $this->eventDispatcher = $eventDispatcher;
+        $this->logger = $logger;
+    }
+
+    protected function configure()
+    {
+        $this->setName('ezplatform:tools:create-data');
+        $this
+            ->addArgument(
+            'iterations',
+            InputArgument::REQUIRED
+            )->addArgument(
+                'editors',
+                InputArgument::REQUIRED,
+            )->addArgument(
+                'language',
+                InputArgument::REQUIRED
+            )->addArgument(
+            'parentPath',
+            InputArgument::REQUIRED
+            )->addArgument(
+        'contentTypeIdentifiers',
+        InputArgument::REQUIRED
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $iterations = $input->getArgument('iterations');
+        $editors = explode(',', $input->getArgument('editors'));
+        $contentTypeData = $this->parseContentTypeData($input->getArgument('contentTypeIdentifiers'));
+        $parentPath = $input->getArgument('parentPath');
+        $language = $input->getArgument('language');
+
+        $stats = sprintf('Starting: %s %s %s', implode(',', $editors), $parentPath, $language);
+        $this->logger->log(LogLevel::INFO, $stats);
+        $this->stopwatch->start('phase');
+
+        $threshhold = 0;
+        foreach ($contentTypeData as $contentTypeIdentifier => $probability) {
+            for ($i = 0; $i < $iterations; ++$i) {
+                if ($threshhold <= $i && $i < $threshhold + $probability * $iterations) {
+                    $this->eventDispatcher->dispatch(TransitionEvent::START,
+                        new TransitionEvent(
+                            $this->getRandomValue($editors, 5),
+                            $contentTypeIdentifier,
+                            $parentPath,
+                            $language
+                        ));
+                }
+            }
+            $threshhold += $probability * $iterations;
+        }
+
+        $event = $this->stopwatch->stop('phase');
+        $statsEnd = sprintf('Ending, duration: %d s, memory: %s MB', $event->getDuration() / 1000, $event->getMemory() / 1024 / 1024);
+        $this->logger->log(LogLevel::INFO, $statsEnd);
+    }
+
+    private function parseContentTypeData(string $data): array
+    {
+        $result = [];
+        $contentTypes = explode(',', $data);
+        foreach ($contentTypes as $contentType) {
+            $contentTypeIdentifier = explode(':', $contentType)[0];
+            $probability = explode(':', $contentType)[1];
+
+            $result[$contentTypeIdentifier] = $probability;
+        }
+
+        return $result;
+    }
+
+    public function getRandomValue(array $values, int $count): string
+    {
+        return $values[random_int(0, $count - 1)];
+    }
+}

--- a/Command/CreateExampleDataManagerCommand.php
+++ b/Command/CreateExampleDataManagerCommand.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class CreateExampleDataManagerCommand extends Command
+{
+    // @TODO: Move to yaml?
+    private $DATA = [
+        'contentTypeIdentifiers' => [
+            ['short_article', 0.75],
+            ['long_article', 0.25],
+        ],
+        'country' => [
+            'france' => [
+                'editors' => ['FrenchEditor1', 'FrenchEditor2', 'FrenchEditor3', 'FrenchEditor4', 'FrenchEditor5'],
+                'subtreePath' => '/Europe/France',
+                'language' => 'fre-FR',
+            ],
+            'germany' => [
+                'editors' => ['GermanEditor1', 'GermanEditor2', 'GermanEditor3', 'GermanEditor4', 'GermanEditor5'],
+                'subtreePath' => '/Europe/Germany',
+                'language' => 'ger-DE',
+            ],
+            'england' => [
+                'editors' => ['EnglishEditor1', 'EnglishEditor2', 'EnglishEditor3', 'EnglishEditor4', 'EnglishEditor5'],
+                'subtreePath' => '/Europe/England',
+                'language' => 'eng-GB',
+            ],
+            'poland' => [
+                'editors' => ['PolishEditor1', 'PolishEditor2', 'PolishEditor3', 'PolishEditor4', 'PolishEditor5'],
+                'subtreePath' => '/Europe/Poland',
+                'language' => 'pol-PL',
+            ],
+            'italy' => [
+                'editors' => ['ItalianEditor1', 'ItalianEditor2', 'ItalianEditor3', 'ItalianEditor4', 'ItalianEditor5'],
+                'subtreePath' => '/Europe/Italy',
+                'language' => 'ita-IT',
+            ],
+            'spain' => [
+                'editors' => ['SpanishEditor1', 'SpanishEditor2', 'SpanishEditor3', 'SpanishEditor4', 'SpanishEditor5'],
+                'subtreePath' => '/Europe/Spain',
+                'language' => 'esl-ES',
+            ],
+            'malta' => [
+                'editors' => ['MalteseEditor1', 'MalteseEditor2', 'MalteseEditor3', 'MalteseEditor4', 'MalteseEditor5'],
+                'subtreePath' => '/Europe/Malta',
+                'language' => 'eng-GB',
+            ],
+            'austria' => [
+                'editors' => ['AustrianEditor1', 'AustrianEditor2', 'AustrianEditor3', 'AustrianEditor4', 'AustrianEditor5'],
+                'subtreePath' => '/Europe/Austria',
+                'language' => 'ger-DE',
+            ],
+            'switzerland' => [
+                'editors' => ['SwissEditor1', 'SwissEditor2', 'SwissEditor3', 'SwissEditor4', 'SwissEditor5'],
+                'subtreePath' => '/Europe/Switzerland',
+                'language' => 'ger-DE',
+            ],
+            'portugal' => [
+                'editors' => ['PortugueseEditor1', 'PortugueseEditor2', 'PortugueseEditor3', 'PortugueseEditor4', 'PortugueseEditor5'],
+                'subtreePath' => '/Europe/Portugal',
+                'language' => 'por-PT',
+            ],
+        ],
+    ];
+
+    /** @var Stopwatch */
+    private $stopwatch;
+
+    /** @var string */
+    private $env;
+
+    /** @var EventDispatcher */
+    private $eventDispatcher;
+
+    public function __construct(string $env, $name = null)
+    {
+        parent::__construct($name);
+        $this->env = $env;
+        $this->stopwatch = new Stopwatch();
+    }
+
+    public function configure()
+    {
+        $this->setName('ezplatform:tools:generate-items');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $processes = [];
+
+        $this->stopwatch->start('timer');
+
+        foreach ($this->DATA['country'] as $key => $values) {
+            $editors = implode(',', $values['editors']);
+            $parentPath = $values['subtreePath'];
+            $language = $values['language'];
+
+            $command = sprintf('%s %s %s %s %s %s',
+                'ezplatform:tools:create-data',
+                100,
+                $editors,
+                $language,
+                $parentPath,
+                $this->parseContentTypes($this->DATA['contentTypeIdentifiers'])
+            );
+            $processes[] = $this->executeCommand($output, $command);
+        }
+
+        while (count($processes)) {
+            foreach ($processes as $i => $runningProcess) {
+                // specific process is finished, so we remove it
+                if (!$runningProcess->isRunning()) {
+                    unset($processes[$i]);
+                }
+
+                // check every second
+                sleep(1);
+            }
+        }
+
+        $event = $this->stopwatch->stop('timer');
+
+        $output->writeln(sprintf('Duration: %d s, memory: %s MB', $event->getDuration() / 1000, $event->getMemory() / 1024 / 1024));
+    }
+
+    public function getRandomValue(array $values, int $count): string
+    {
+        return $values[random_int(0, $count - 1)];
+    }
+
+    private function executeCommand(OutputInterface $output, $cmd, $timeout = 1200)
+    {
+        $phpFinder = new PhpExecutableFinder();
+        if (!$phpPath = $phpFinder->find(false)) {
+            throw new \RuntimeException('The php executable could not be found, add it to your PATH environment variable and try again');
+        }
+
+        // We don't know which php arguments where used so we gather some to be on the safe side
+        $arguments = $phpFinder->findArguments();
+        if (false !== ($ini = php_ini_loaded_file())) {
+            $arguments[] = '--php-ini=' . $ini;
+        }
+
+        // Pass memory_limit in case this was specified as php argument, if not it will most likely be same as $ini.
+        if ($memoryLimit = ini_get('memory_limit')) {
+            $arguments[] = '-d memory_limit=' . $memoryLimit;
+        }
+
+        $phpArgs = implode(' ', array_map('escapeshellarg', $arguments));
+        $php = escapeshellarg($phpPath) . ($phpArgs ? ' ' . $phpArgs : '');
+
+        // Make sure to pass along relevant global Symfony options to console command
+        $console = escapeshellarg('bin/console');
+        if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+            $console .= ' -' . str_repeat('v', $output->getVerbosity() - 1);
+        }
+
+        if ($output->isDecorated()) {
+            $console .= ' --ansi';
+        }
+
+        $console .= ' --env=' . escapeshellarg($this->env);
+
+        $process = new Process($php . ' ' . $console . ' ' . $cmd, null, null, null, $timeout);
+        $process->start(function ($type, $buffer) use ($output) { $output->write($buffer, false); });
+
+        return $process;
+    }
+
+    private function parseContentTypes(array $contentTypeData): string
+    {
+        $results = [];
+        foreach ($contentTypeData as $contentType) {
+            $results[] = implode(':', $contentType);
+        }
+
+        return implode(',', $results);
+    }
+}

--- a/Event/TransitionEvent.php
+++ b/Event/TransitionEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class TransitionEvent extends Event
+{
+    public const START = 'start';
+
+    public const DRAFT_TO_PUBLISH = 'transition.draft_to_publish';
+
+    public const DRAFT_TO_END = 'transition.draft_to_end';
+
+    public const PUBLISH_TO_END = 'transition.publish_to_end';
+
+    public const PUBLISH_TO_EDIT = 'transition.publish_to_edit';
+
+    public const EDIT_TO_PUBLISH = 'transition.edit_to_publish';
+
+    public const EDIT_TO_END = 'transition.edit_to_end';
+
+    public const EDIT_TO_EDIT = 'transition.edit_to_edit';
+
+    /**
+     * @var string
+     */
+    public $userName;
+    /**
+     * @var string
+     */
+    public $parentPath;
+    /**
+     * @var string
+     */
+    public $language;
+    /**
+     * @var string
+     */
+    public $contentTypeIdentifier;
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    public $content;
+
+    public function __construct(string $userName, string $contentTypeIdentifier, string $parentPath, string $language)
+    {
+        $this->userName = $userName;
+        $this->parentPath = $parentPath;
+        $this->language = $language;
+        $this->contentTypeIdentifier = $contentTypeIdentifier;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: services/fieldtype_data_providers.yaml }
     - { resource: services/limitation_parsers.yaml }
+    - { resource: services/stages.yaml }
 
 services:
     _defaults:
@@ -34,7 +35,20 @@ services:
     EzSystems\BehatBundle\API\Facade\LanguageFacade:
         public: true
 
+    EzSystems\BehatBundle\API\Facade\SearchFacade:
+        arguments:
+            - '@eZ\Publish\API\Repository\URLAliasService'
+            - '@eZ\Publish\API\Repository\LocationService'
+            - '@ezpublish.api.service.search'
+
     EzSystems\BehatBundle\Helper\ArgumentParser:
         public: true
         arguments:
             - '@EzSystems\BehatBundle\API\Facade\RoleFacade'
+
+    EzSystems\BehatBundle\Command\CreateExampleDataCommand: ~
+
+    EzSystems\BehatBundle\Command\CreateExampleDataManagerCommand:
+        arguments:
+            - '%kernel.environment%'
+

--- a/Resources/config/services/stages.yaml
+++ b/Resources/config/services/stages.yaml
@@ -1,0 +1,11 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\BehatBundle\Subscriber\CreateContentDraft: ~
+
+    EzSystems\BehatBundle\Subscriber\PublishDraft: ~
+
+    EzSystems\BehatBundle\Subscriber\EditContent: ~

--- a/Subscriber/AbstractProcessStage.php
+++ b/Subscriber/AbstractProcessStage.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Subscriber;
+
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\UserService;
+use PHPUnit\Framework\Assert;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+abstract class AbstractProcessStage
+{
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
+    /** @var EventDispatcher */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcher $eventDispatcher, UserService $userService, PermissionResolver $permissionResolver, LoggerInterface $logger)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->userService = $userService;
+        $this->permissionResolver = $permissionResolver;
+        $this->logger = $logger;
+        $this->validateTransitions();
+    }
+
+    abstract protected function getTransitions(): array;
+
+    protected function transitionToNextStage($eventData)
+    {
+        $threshold = 0;
+        $randomValue = $this->getRandomNumber();
+
+        $chosenEvent = null;
+
+        foreach ($this->getTransitions() as $eventName => $probability) {
+            if ($threshold <= $randomValue && $randomValue < $threshold + $probability) {
+                $chosenEvent = $eventName;
+            }
+
+            $threshold += $probability;
+        }
+
+        if (!$chosenEvent) {
+            Assert::fail('No event was chosen, possible error in transition logic.');
+        }
+
+        $this->eventDispatcher->dispatch($chosenEvent, $eventData);
+    }
+
+    protected function setCurrentUser(string $user): void
+    {
+        $user = $this->userService->loadUserByLogin($user);
+        $this->permissionResolver->setCurrentUserReference($user);
+    }
+
+    protected function validateTransitions(): void
+    {
+        $sum = 0;
+        foreach ($this->getTransitions() as $event => $probability) {
+            $sum += $probability;
+        }
+
+        Assert::assertEquals(1, $sum, 'Sum of all probabilities must be equal to 1.');
+    }
+
+    protected function getRandomNumber(): float
+    {
+        return random_int(0, 999) / 1000;
+    }
+}

--- a/Subscriber/CreateContentDraft.php
+++ b/Subscriber/CreateContentDraft.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Subscriber;
+
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\BehatBundle\API\Facade\ContentFacade;
+use EzSystems\BehatBundle\API\Facade\SearchFacade;
+use EzSystems\BehatBundle\Event\TransitionEvent;
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CreateContentDraft extends AbstractProcessStage implements EventSubscriberInterface
+{
+    /** @var \EzSystems\BehatBundle\API\Facade\ContentFacade */
+    private $contentFacade;
+
+    /** @var \EzSystems\BehatBundle\API\Facade\SearchFacade */
+    private $searchFacade;
+
+    public static function getSubscribedEvents()
+    {
+        return [TransitionEvent::START => 'onProcessStarted'];
+    }
+
+    protected function getTransitions(): array
+    {
+        return [
+            TransitionEvent::DRAFT_TO_END => 0.1,
+            TransitionEvent::DRAFT_TO_PUBLISH => 0.9,
+        ];
+    }
+
+    public function __construct(EventDispatcher $eventDispatcher,
+                                UserService $userService,
+                                PermissionResolver $permissionResolver,
+                                LoggerInterface $logger,
+                                ContentFacade $contentFacade,
+                                SearchFacade $searchFacade)
+    {
+        parent::__construct($eventDispatcher, $userService, $permissionResolver, $logger);
+        $this->contentFacade = $contentFacade;
+        $this->searchFacade = $searchFacade;
+    }
+
+    public function onProcessStarted(TransitionEvent $eventData): void
+    {
+        $this->setCurrentUser($eventData->userName);
+
+        try {
+            $parentPath = $this->searchFacade->getRandomChildFromPath($eventData->parentPath);
+            $content = $this->contentFacade->createContentDraft($eventData->contentTypeIdentifier, $parentPath, $eventData->language);
+            $eventData->content = $content;
+            $this->transitionToNextStage($eventData);
+        } catch (Exception $ex) {
+            $this->logger->log(LogLevel::ERROR, sprintf('Error occured during CreateContentDraft Stage: %s', $ex->getMessage()));
+        }
+    }
+}

--- a/Subscriber/EditContent.php
+++ b/Subscriber/EditContent.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Subscriber;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\BehatBundle\API\ContentData\ContentDataProvider;
+use EzSystems\BehatBundle\Event\TransitionEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class EditContent extends AbstractProcessStage implements EventSubscriberInterface
+{
+    /**
+     * @var ContentDataProvider
+     */
+    private $contentDataProvider;
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    protected function getTransitions(): array
+    {
+        return [
+            TransitionEvent::EDIT_TO_END => 0.4,
+            TransitionEvent::EDIT_TO_PUBLISH => 0.5,
+            TransitionEvent::EDIT_TO_EDIT => 0.1,
+        ];
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            TransitionEvent::EDIT_TO_EDIT => 'editContent',
+            TransitionEvent::PUBLISH_TO_EDIT => 'editContent',
+        ];
+    }
+
+    public function __construct(LoggerInterface $logger, ContentDataProvider $contentDataProvider, ContentService $contentService, EventDispatcher $eventDispatcher, UserService $userService, PermissionResolver $permissionResolver)
+    {
+        parent::__construct($eventDispatcher, $userService, $permissionResolver, $logger);
+        $this->contentDataProvider = $contentDataProvider;
+        $this->contentService = $contentService;
+    }
+
+    public function editContent(TransitionEvent $event)
+    {
+        try {
+            $this->contentDataProvider->setContentTypeIdentifier($event->contentTypeIdentifier);
+            $contentUpdateStruct = $this->contentDataProvider->getRandomContentUpdateData($event->language);
+
+            $contentDraft = $this->contentService->createContentDraft($event->content->contentInfo);
+            $updatedDraft = $this->contentService->updateContent($contentDraft->getVersionInfo(), $contentUpdateStruct);
+            $event->content = $updatedDraft;
+
+            $this->transitionToNextStage($event);
+        } catch (Exception $ex) {
+            $this->logger->log(LogLevel::ERROR, sprintf('Error occured during EditContent Stage: %s', $ex->getMessage()));
+        }
+    }
+}

--- a/Subscriber/PublishDraft.php
+++ b/Subscriber/PublishDraft.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Subscriber;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\UserService;
+use EzSystems\BehatBundle\Event\TransitionEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PublishDraft extends AbstractProcessStage implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    protected function getTransitions(): array
+    {
+        return [
+            TransitionEvent::PUBLISH_TO_END => 0.3,
+            TransitionEvent::PUBLISH_TO_EDIT => 0.7,
+        ];
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            TransitionEvent::DRAFT_TO_PUBLISH => 'publishDraft',
+            TransitionEvent::EDIT_TO_PUBLISH => 'publishDraft',
+        ];
+    }
+
+    public function __construct(EventDispatcher $eventDispatcher, UserService $userService, PermissionResolver $permissionResolver, LoggerInterface $logger, ContentService $contentService)
+    {
+        parent::__construct($eventDispatcher, $userService, $permissionResolver, $logger);
+        $this->contentService = $contentService;
+    }
+
+    public function publishDraft(TransitionEvent $event)
+    {
+        try {
+            $event->content = $this->contentService->publishVersion($event->content->versionInfo);
+            $this->transitionToNextStage($event);
+        } catch (Exception $ex) {
+            $this->logger->log(LogLevel::ERROR, sprintf('Error occured during CreateContentDraft Stage: %s', $ex->getMessage()));
+        }
+    }
+}

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -18,6 +18,17 @@ behat:
 
 setup:
     suites:
+        volume_testing:
+            paths:
+                - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/features/setup/volume/
+            contexts:
+                - EzSystems\BehatBundle\Context\Api\TestContext
+                - EzSystems\BehatBundle\Context\Object\UserContext
+                - EzSystems\BehatBundle\Context\Object\RoleContext
+                - EzSystems\BehatBundle\Context\Object\ContentType
+                - EzSystems\BehatBundle\Context\Object\ContentContext
+                - EzSystems\BehatBundle\Context\Object\ContentTypeContext
+                - EzSystems\BehatBundle\Context\Object\LanguageContext
         richtext_configuration:
             paths:
                 - vendor/ezsystems/behatbundle/EzSystems/BehatBundle/features/richtextConfiguration/custom_tags.feature

--- a/features/setup/volume/content_items.feature
+++ b/features/setup/volume/content_items.feature
@@ -1,0 +1,139 @@
+Feature: Create Content Items used for volue testing
+
+  @admin @contentItems
+  Scenario: Create a language, Content Type and Content Items
+    Given I create "Folder" Content items in root in "eng-GB"
+      | name   | short_name  |
+      | Europe | Europe      |
+    And I create "Folder" Content items in "Europe" in "eng-GB"
+      | name        | short_name  |
+      | France      | France      |
+      | Poland      | Poland      |
+      | Germany     | Germany     |
+      | England     | England     |
+      | Italy       | Italy       |
+      | Spain       | Spain       |
+      | Portugal    | Portugal    |
+      | Malta       | Malta       |
+      | Austria     | Austria     |
+      | Switzerland | Switzerland |
+    And I create "Folder" Content items in "Europe/France" in "eng-GB"
+      | name        | short_name  |
+      | Paris       | Paris       |
+      | Bordeaux    | Bordeaux    |
+      | Marseille   | Marseille   |
+      | Nantes      | Nantes      |
+      | Lyon        | Lyon        |
+      | Toulouse    | Toulouse    |
+      | Nice        | Nice        |
+      | Montpellier | Montpellier |
+      | Strasbourg  | Strasbourg  |
+      | Lille       | Lille       |
+    And I create "Folder" Content items in "Europe/Poland" in "eng-GB"
+      | name      | short_name |
+      | Katowice  | Katowice   |
+      | Warszawa  | Warszawa   |
+      | Krakow    | Krakow     |
+      | Gdansk    | Gdansk     |
+      | Wroclaw   | Wroclaw    |
+      | Poznan    | Poznan     |
+      | Lublin    | Lubin      |
+      | Zabrze    | Zabrze     |
+      | Gliwice   | Gliwice    |
+      | Bialystok | Bialystok  |
+    And I create "Folder" Content items in "Europe/Germany" in "eng-GB"
+      | name       | short_name |
+      | Berlin     | Berlin     |
+      | Munich     | Munich     |
+      | Frankfurt  | Frankfurt  |
+      | Nuremberg  | Nuremberg  |
+      | Stuttgart  | Stuttgart  |
+      | Hamburg    | Hamburg    |
+      | Cologne    | Cologne    |
+      | Dusseldorf | Dusseldorf |
+      | Dortmund   | Dortmund   |
+      | Essen      | Essen      |
+    And I create "Folder" Content items in "Europe/England" in "eng-GB"
+      | name       | short_name |
+      | Birmingham | Birmingham |
+      | Bristol    | Bristol    |
+      | Cambridge  | Cambridge  |
+      | Liverpool  | Liverpool  |
+      | London     | London     |
+      | Leeds      | Leeds      |
+      | Cornwall   | Cornwall   |
+      | Manchester | Manchester |
+      | Bradford   | Bradford   |
+      | Durham     | Durham     |
+    And I create "Folder" Content items in "Europe/Italy" in "eng-GB"
+      | name       | short_name |
+      | Rome       | Rome       |
+      | Turin      | Turin      |
+      | Milan      | Milan      |
+      | Naples     | Naples     |
+      | Palermo    | Palermo    |
+      | Genoa      | Genoa      |
+      | Bologna    | Bologna    |
+      | Florence   | Florence   |
+      | Bari       | Bari       |
+      | Venice     | Venice     |
+    And I create "Folder" Content items in "Europe/Spain" in "eng-GB"
+      | name       | short_name |
+      | Madrid     | Madrid     |
+      | Barcelona  | Barcelona  |
+      | Valencia   | Valencia   |
+      | Sevilla    | Sevilla    |
+      | Zaragoza   | Zaragoza   |
+      | Malaga     | Malaga     |
+      | Murcia     | Murcia     |
+      | Palma      | Palma      |
+      | Bilbao     | Bilbao     |
+      | Cordoba    | Cordoba    |
+    And I create "Folder" Content items in "Europe/Malta" in "eng-GB"
+      | name       | short_name |
+      | Mdina      | Mdina      |
+      | Qormi      | Qormi      |
+      | Rabat      | Rabat      |
+      | Valletta   | Valletta   |
+      | Birgu      | Birgu      |
+      | Bormla     | Bormla     |
+      | Senglea    | Senglea    |
+      | Siggiewi   | Siggiewi   |
+      | Zabbar     | Zabbar     |
+      | Zebbug     | Zebbug     |
+    And I create "Folder" Content items in "Europe/Austria" in "eng-GB"
+      | name       | short_name |
+      | Vienna     | Vienna     |
+      | Graz       | Graz       |
+      | Linz       | Linz       |
+      | Salzburg   | Salzburg   |
+      | Innsbruck  | Innsbruck  |
+      | Klagenfurt | Klagenfurt |
+      | Bregenz    | Bregenz    |
+      | Eisenstadt | Eisenstadt |
+      | Villach    | Villach    |
+      | Retz       | Retz       |
+    And I create "Folder" Content items in "Europe/Switzerland" in "eng-GB"
+      | name       | short_name |
+      | Zurich     | Zurich     |
+      | Geneva     | Geneva     |
+      | Basel      | Basel      |
+      | Bern       | Bern       |
+      | Lugano     | Lugano     |
+      | Sion       | Sion       |
+      | Uster      | Uster      |
+      | Vernier    | Vernier    |
+      | Chur       | Chur       |
+      | Thun       | Thun       |
+    And I create "Folder" Content items in "Europe/Portugal" in "por-PT"
+      | name       | short_name |
+      | Lisbon     | Lisbon     |
+      | Porto      | Porto      |
+      | Amadora    | Amadora    |
+      | Braga      | Braga      |
+      | Coimbra    | Coimbra    |
+      | Funchal    | Funchal    |
+      | Almada     | Almada     |
+      | Setubal    | Setubal    |
+      | Queluz     | Queluz     |
+      | Viseu      | Viseu      |

--- a/features/setup/volume/content_types.feature
+++ b/features/setup/volume/content_types.feature
@@ -1,0 +1,17 @@
+Feature: Create Content Types required for volume testing
+
+  @admin @contentTypes
+  Scenario: Create Content Types used in volume testing
+    Given I create a "LongArticle" Content Type in "Content" with "long_article" identifier
+      | Field Type                   | Name              | Identifier  | Required | Searchable | Translatable |
+      | Text line                    | Name              | name	       | no       | yes	       | yes          |
+      | Text line                    | Short description | short       | no       | yes        | yes          |
+      | Rich text                    | Content1          | content1    | no       | yes        | yes          |
+      | Image                        | Image             | image       | yes      | no         | yes          |
+      | Rich text                    | Content2          | content2    | no       | yes        | yes          |
+      | Content relations (multiple) | Similar items     | similar     | yes      | yes        | yes          |
+    And I create a "ShortArticle" Content Type in "Content" with "short_article" identifier
+      | Field Type  | Name              | Identifier  | Required | Searchable | Translatable |
+      | Text line   | Name              | name	      | no       | yes	      | yes          |
+      | Text line   | Short description | short       | no       | yes        | yes          |
+      | Rich text   | Content           | content     | no       | yes        | yes          |

--- a/features/setup/volume/languages.feature
+++ b/features/setup/volume/languages.feature
@@ -1,0 +1,11 @@
+Feature: Create languages required for volume testing
+
+  @admin @language
+  Scenario: Create languages used in volume testing
+    Given Language "Polski" with code "pol-PL" exists
+    And Language "French" with code "fre-FR" exists
+    And Language "English" with code "eng-GB" exists
+    And Language "German" with code "ger-DE" exists
+    And Language "Italian" with code "ita-IT" exists
+    And Language "Spanish" with code "esl-ES" exists
+    And Language "Portuguese" with code "por-PT" exists

--- a/features/setup/volume/users.feature
+++ b/features/setup/volume/users.feature
@@ -1,0 +1,46 @@
+Feature: Create languages required for volume testing
+
+  @admin @users
+  Scenario Outline: Create users for specific regions
+    Given I create a user group "<groupName>"
+    And I create a user "<userName>1" with last name "<userName>1" in group "<groupName>"
+    And I create a user "<userName>2" with last name "<userName>2" in group "<groupName>"
+    And I create a user "<userName>3" with last name "<userName>3" in group "<groupName>"
+    And I create a user "<userName>4" with last name "<userName>4" in group "<groupName>"
+    And I create a user "<userName>5" with last name "<userName>5" in group "<groupName>"
+    And I create a role "<roleName>Basic" with policies
+    | module      | function           |
+    | user        | login              |
+    And I add policy "content" "read" to "<roleName>Basic" with limitations
+    | limitationType      | limitationValue |
+    | Location            | root,/Europe    |
+    And I add policy "content" "versionread" to "<roleName>Basic" with limitations
+    | limitationType      | limitationValue     |
+    | Location            | root,/Europe        |
+    And I assign user group "<groupName>" to role "<roleName>Basic"
+    And I create a role "<roleName>Limited" with policies
+      | module      | function           |
+      | content     | read               |
+      | content     | versionread        |
+      | content     | create             |
+      | content     | publish            |
+      | content     | remove             |
+      | content     | edit               |
+      | section     | view               |
+      | content     | reverserelatedlist |
+    And I assign user group "<groupName>" to role "<roleName>Limited" with limitations:
+      | limitationType      | limitationValue        |
+      | Subtree             | /Europe/<rootItemName> |
+
+    Examples:
+    | groupName         | userName         |  roleName            | rootItemName |
+    | FrenchEditors     | FrenchEditor     | FrenchEditorsRole    | France       |
+    | GermanEditors     | GermanEditor     | GermanEditorsRole    | Germany      |
+    | PolishEditors     | PolishEditor     | PolishEditorsRole    | Poland       |
+    | EnglishEditors    | EnglishEditor    | EnglishEditorsRole   | England      |
+    | ItalianEditors    | ItalianEditor    | ItalianEditorsRole   | Italy        |
+    | SpanishEditors    | SpanishEditor    | SpanishEditorsRole   | Spain        |
+    | MalteseEditors    | MalteseEditor    | MalteseEditorsRole   | Malta        |
+    | SwissEditors      | SwissEditor      | SwissEditorsRole     | Switzerland  |
+    | AustrianEditors   | AustrianEditor   | AustrianEditorROle   | Austria      |
+    | PortugueseEditors | PortugueseEditor | PortugueseEditorRole | Portugal     |


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31525

## Volume testing - introduction
The goal of this spike is to explore the options that we can use to generate millions of objects, large content structure, and multiple version.

## Live demo
A site with 300k Content Items: https://master-7rqtwti-hurg7yxf3msf4.eu-4.platformsh.site/
Login using admin/publish or one of the example editors:
- FrenchEditor1/Passw0rd-42
- PolishEditor3/Passw0rd-42
- SpanishEditor5/Passw0rd-42
(there are 50 Editors created for the tests).

Feel free to experiment, you can create/edit etc. - just please don't delete large Subtrees and don't mess with existing permissions (but you can create new Users if you want to).

## Environment
We will be using Enterprise version for the tests (both on v2 and v3).

## Options
It is be possible to generate lots of data using:
- REST
- Behat
- PHP API
- SQL inserts

I've chosen to go with PHP API because:
1) it's faster than Behat/REST (which use it under the hood, but with Behat/HTTP overhead)
2) There are no limitations when using PHP compared to others methods (for example there is no REST API for Workflow and no Behat Contexts for many services which would need to be developed)
3) PHP code is easier to maintain and more flexible than Behat/REST solutions (SQL inserts are not maintainable at all)

## Current solution

### Setup

Setup is created using Behat features - it is static and rarely changes, so there is no need to create it using PHP (and we already have all the Behat steps needed).

#### Content Items
I've decided to go with 10 "main" Content Items, where each has ten Content Items as children:
<img width="377" alt="Zrzut ekranu 2020-05-4 o 13 19 11" src="https://user-images.githubusercontent.com/10993858/80960788-da81a200-8e09-11ea-988b-638d4a4ee3b9.png">

#### Content Types
For now there are two Content Types: long_article (with image and object relations) and short_article (text fields only).

#### Languages
I've added a couple of languages to make the setup look more realistic

#### Users
Each country has 5 Editors, for example France has FrenchEditor1, FrenchEditor2 etc.
They are based on SubtreeEditor - they have access only to Content Items located under the country they are writing for and do not see other Countries at all.

### Creation 

The idea was to create a flexible model that can be adjusted in the future. I've decided to implement a model based on [Markov chains](https://en.wikipedia.org/wiki/Markov_chain) and Symfony Events - this allows us to create Content Items that vary from each other. The current model looks like this:

![diagram](https://user-images.githubusercontent.com/10993858/80965870-9eebd580-8e13-11ea-80ea-12803d9cb9fc.png)

Create Content Draft is the initial state, the arrows define available transitions and their probability. For Content Draft there are two transitions:
- end process (10% of Content Items will stay as unpublished Drafts)
- publish the Draft (90% of Drafts will be published) and continue with transitions until the end state is reached.

I believe this approach allows us to achieve a realistic model. This one is pretty basic - we could expand it to add Translations, use Workflow etc., but it's not in scope of this spike and requires talking with Support about real world product usage. The location of Content Draft is chosen at random* as a child under the specific country - this does not result in a deep Content tree, something that can be improved in the future.

*that depends on SQL engine and there is no Random SortClause in 2.5, I've tried to workaround it a bit but something that can be improved

#### Running:
1) We cannot run it on Platform.sh, because by default the disk space is 5gb (and Content Items with images quicky take more space). My current approach is to run it locally, upload the backup to Platform.sh and use [image placeholders](https://doc.ezplatform.com/en/master/guide/images/#setting-placeholder-generator).
2) Use all suggestions from [our performance guide](https://doc.ezplatform.com/en/2.5/guide/performance/) (disable xdebug, use PHP 7.4, SYMFONY_ENV=prod, SYMFONY_DEBUG 0).
This requires adding BehatBundle to the list of bundles loaded in prod env. Also I've experimented with using `cache.null` adapter (https://github.com/mateuszbieniek/ezplatform-database-health-checker/blob/master/src/bundle/Resources/config/cache_pool/cache.null.yml) which was the fastest in my tests (with redis the process was ca. 10% slower).
3) I've also went with running the Commands in parallel, as suggested in:
[our doc](https://doc.ezplatform.com/en/2.5/guide/performance/#reducing-memory-usage)
and this blogpost: https://www.tomasvotruba.com/blog/2018/02/05/how-to-run-symfony-processes-asynchronously/
Right now there are two separate Commands - we probably should unite them into one, but we would need to extract the code from kernel that allows to run multiprocess Commands and make it reusable, so I didn't want to spend time on that.

The process to run it looks like this:
- switch to SYMFONY_ENV=prod, SYMFONY_DEBUG=0, disable xdebug, use PHP7.4 if possible
- add a cache.null adapter and use it: export CACHE_POOL=cache.null
- switch the list of loaded bundles so that BehatBundle is loaded in prod
- switch Behat to run in prod and no debug (in behat.yml.dist)
- run setup:
```
bin/behat --profile=setup --suite=volume_testing --tags=@language
bin/behat --profile=setup --suite=volume_testing --tags=@contentTypes
bin/behat --profile=setup --suite=volume_testing --tags=@contentItems
bin/behat --profile=setup --suite=volume_testing --tags=@users
```
- run command:
`php bin/console ezplatform:tools:generate-items` - this creates 1k Content Items, 100 for each Country.

To run it multiple times use bash, something like:
```
#!/bin/bash
for i in {1..1000}
do
	echo "Iteration: $i"
	php bin/console ezplatform:tools:generate-items
done
```


#### Problems:
1) When running with multiple processes I've encountered database deadlocks (previously reported in https://jira.ez.no/browse/EZP-31037). For now I've surrounded every action in Stages with try/catch blocks.
2) When the database is empty it takes 2 minutes to create 1k Content Items, with 300k Content Items already in the database it took 11 minutes. Without a huge speedup the script might need to run for a long time to reach 1mln items. It took me ca. 24h to create 300k Content Items. Right now I think the bottleneck might be in searching Content Items for relation, but I will need to investigate it. It is possible to achieve a 10% speedup by caching results from ContentDataProvider, maybe something similar can be done there.

### Evaluation
This is something that still needs to be done, but my current approach would look like this:
- Use existing editors or create new ones (for example Editors that can only access `long_article` Content Items etc., to make things more interesting).
- For all created users perform some tasks in the browser (for example: load dashboard, load Content Tree, open UDW, create a new Content Item, edit a Content Item, load subitems)
- capture the requests with Postman (https://learning.postman.com/docs/postman/sending-api-requests/capturing-http-requests/), export it as a collection and  automate the process (in the future) so we can make sure that our limits are not exceeded.

I will be happy to hear any suggestions/answer questions.

