### PR TITLE
EZP-31560: Updated composer.json to support Composer 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,30 @@
 {
     "name": "ezsystems/behatbundle",
     "description": "Behat bundle for help testing eZ Bundles and projects",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-only",
     "authors": [
         {
-            "name": "eZ Publish dev-team & eZ Community",
+            "name": "eZ Platform dev-team & eZ Community",
             "homepage": "https://github.com/ezsystems/BehatBundle/graphs/contributors"
         }
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "ezsystems/ezpublish-kernel": "*",
+        "ezsystems/ezpublish-kernel": "^6.13@dev",
         "phpunit/phpunit": "^5.7|^6.0|^7.0"
     },
     "autoload": {
-        "psr-0": {"EzSystems\\BehatBundle": ""}
+        "psr-4": {
+            "EzSystems\\BehatBundle\\": ""
+        }
     },
-    "target-dir": "EzSystems/BehatBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "6.5.x-dev",
             "dev-tmp_ci_branch": "6.5.x-dev"
         }
     },
-
-    "bin": ["bin/ezbehat"]
+    "bin": [
+        "bin/ezbehat"
+    ]
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31560](https://jira.ez.no/browse/EZP-31560)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.5`, `7.0` **only** (undo on merge up to 8.0)
| **BC breaks**      | no
| **Doc needed**     | no

This PR enables support of Composer 2.x by getting rid of deprecation issues it reports now.
Steps to reproduce with Composer 1.x:
```
composer install --optimize-autoloader
```

The namespace for autoloader was defined as:
```json
"psr-0": {"EzSystems\\BehatBundle": ""}
"target-dir": "EzSystems/BehatBundle",
```
`psr-0` could stay if it didn't have `target-dir` set. On the other hand w/o `target-dir` directory structure would need to be updated for the namespace to work, which is too extensive.

Therefore I've switched namespace to PSR-4. TBD if that works when installed from meta-repository.

Besides that, a deprecated `GPL-2.0` license reference was changed to `GPL-2.0-only` and ezpublish-kernel requirement was locked at the lowest supported `^6.13@dev`. It's not possible to go any lower, because those older Kernel versions are also not Composer 2.x-ready.

Keep in mind that the change is as small as possible, because the stable 8.0 seems not to cause those issues (namespaces are correct). 
However are more changes to come for `7.0` via #150 (will be re-done to be a merge up).

See [EZP-31560](https://jira.ez.no/browse/EZP-31560) for more details about the composer deprecation notice.

**TODO**:
- [x] Fix namespaces.
- [ ] Wait for Travis.
- [ ] Ask for Code Review.
