### PR TITLE
Removed trailing comma

### DIFF
--- a/Command/CreateExampleDataCommand.php
+++ b/Command/CreateExampleDataCommand.php
@@ -42,7 +42,7 @@ class CreateExampleDataCommand extends Command
             InputArgument::REQUIRED
             )->addArgument(
                 'editors',
-                InputArgument::REQUIRED,
+                InputArgument::REQUIRED
             )->addArgument(
                 'language',
                 InputArgument::REQUIRED


### PR DESCRIPTION
Follow-up to https://github.com/ezsystems/BehatBundle/pull/151 - trailing comma in function call is a valid language construct in PHP 7.3 - https://laravel-news.com/php-trailing-commas-functions -  but not in PHP 7.1, which is supported by eZ Platform 2.5.

Failing build: https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/684633871#L781
Thanks to @alongosz for finding that!