### PR TITLE
[Composer] Removed beta stability requirement for friends-of-behat/sy…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "behat/behat": "^3.6",
         "friends-of-behat/mink": "^1.8",
         "behat/mink-selenium2-driver": "^1.4",
-        "friends-of-behat/symfony-extension": "^2.1@beta",
+        "friends-of-behat/symfony-extension": "^2.1",
         "friends-of-behat/mink-extension": "^2.4",
         "php-http/client-common": "^2.1",
         "symfony/property-access": "^5.0",


### PR DESCRIPTION
…mfony-extension

Same as in https://github.com/ezsystems/ezplatform/pull/565#pullrequestreview-432142749 - there is a stable release already: https://github.com/FriendsOfBehat/SymfonyExtension/releases/tag/v2.1.0