### PR TITLE
Changed sorting order in listing Features for fastest

### DIFF
--- a/bin/ezbehat
+++ b/bin/ezbehat
@@ -54,10 +54,9 @@ fastest(){
 # Fastest option 'list-features' gives us the list of all features from given context in random order, which are later
 # run in this order in few threads and dynamically distributed between these threads. That gives us different test build
 # times each build, often non optimal. To make this optimal we sort features by the number of scenarios in them
-# (ascending because Fastest reverse the queue order, and we want this queue to run descending) and run them in that order,
-# to minimize final time gap between the threads.
+# (descending) and run them in that order, to minimize final time gap between the threads.
 get_behat_features(){
-    bin/behat ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort | awk '{ print $2 }'
+    bin/behat ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
 }
 
 for i in "$@"


### PR DESCRIPTION
Backporting https://github.com/ezsystems/BehatBundle/pull/136 to 7.0 branch - the latest release from https://github.com/liuggio/fastest/releases contains the bugfix we had a workaround for.

You can see here: https://travis-ci.org/github/ezsystems/ezplatform-admin-ui/jobs/702328281
that ContentTypeFields.feature should start as the first one because it's the longest one. it's the last instead.