### PR TITLE
Corrected contentTypeIdentifier for case sensitive systems

### DIFF
--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -6,17 +6,17 @@ Feature: Editor that has access only to a Subtree of Content Structure
       | Field Type  | Name         | Identifier        | Required | Searchable | Translatable |
       | Text line   | Name         | name	           | yes      | yes	       | yes          |
       | Text line   | Short name   | short_name        | yes      | no	       | yes          |
-    And I create "DedicatedFolder" Content items in root in "eng-GB"
+    And I create "dedicatedFolder" Content items in root in "eng-GB"
       | name              | short_name        |
       | FolderGrandParent | FolderGrandParent |
-    And I create "DedicatedFolder" Content items in "FolderGrandParent" in "eng-GB"
+    And I create "dedicatedFolder" Content items in "FolderGrandParent" in "eng-GB"
       | name         | short_name   |
       | FolderParent | FolderParent |
-    And I create "DedicatedFolder" Content items in "FolderGrandParent/FolderParent" in "eng-GB"
+    And I create "dedicatedFolder" Content items in "FolderGrandParent/FolderParent" in "eng-GB"
       | name         | short_name   |
       | FolderChild1 | FolderChild1 |
       | FolderChild2 | FolderChild2 |
-    And I create "DedicatedFolder" Content items in "FolderGrandParent/FolderParent/FolderChild1" in "eng-GB"
+    And I create "dedicatedFolder" Content items in "FolderGrandParent/FolderParent/FolderChild1" in "eng-GB"
       | name          | short_name    |
       | ContentToMove | ContentToMove |
     And I create a user group "SubtreeEditorsGroup"


### PR DESCRIPTION
The first step creates a Content Type with `dedicatedFolder` Content Type identifier:
```
I create a "DedicatedFolder" Content Type in "Content" with "dedicatedFolder" identifier
```

But the next steps (`I create "DedicatedFolder" Content items in root in "eng-GB"`) are using Content Type Name instead - it works on mysql (which seems to ignore the difference in casing) but fails on PostgreSQL. 

The "I create..." step expects contentTypeIdentifier, see:https://github.com/ezsystems/BehatBundle/blob/master/src/lib/API/Context/ContentContext.php#L41