### PR TITLE
EZP-32103: Add Varnish integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
+        "dmore/chrome-mink-driver": "^2.7",
+        "ezsystems/ezplatform-http-cache": "^2.1",
         "ezsystems/ezplatform-kernel": "~1.1.0@dev",
         "fzaninotto/faker": "^1.9",
         "guzzlehttp/psr7": "^1.6.1",
@@ -55,6 +57,5 @@
             "dev-tmp_ci_branch": "8.1.x-dev"
         }
     },
-
     "bin": ["bin/ezbehat", "bin/ezreport"]
 }

--- a/src/lib/Browser/Context/BrowserContext.php
+++ b/src/lib/Browser/Context/BrowserContext.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Assert;
 use WebDriver\Exception\ElementNotVisible;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
+use DMore\ChromeDriver\ChromeDriver;
 
 class BrowserContext extends MinkContext
 {
@@ -346,8 +347,18 @@ class BrowserContext extends MinkContext
     public function responseHeadersContain(TableNode $expectedHeadersData): void
     {
         $responseHeaders = $this->getSession()->getDriver()->getResponseHeaders();
+
         foreach ($expectedHeadersData->getHash() as $row) {
-            Assert::assertEquals($row['Value'], $responseHeaders[$row['Header']][0]);
+            Assert::assertEquals($row['Value'], $this->getHeaderValue($responseHeaders, $row['Header']));
         }
+    }
+
+    private function getHeaderValue($responseHeaders, $header): string
+    {
+        if ($this->getSession()->getDriver() instanceof ChromeDriver) {
+            return $responseHeaders[$header];
+        }
+
+        return $responseHeaders[$header][0];
     }
 }

--- a/src/lib/Browser/Page/FrontendLoginPage.php
+++ b/src/lib/Browser/Page/FrontendLoginPage.php
@@ -6,6 +6,8 @@
  */
 namespace EzSystems\Behat\Browser\Page;
 
+use PHPUnit\Framework\Assert;
+
 class FrontendLoginPage extends Page
 {
     /** @var string Name by which Page is recognised */
@@ -26,5 +28,7 @@ class FrontendLoginPage extends Page
         $this->context->findElement('#username')->setValue($username);
         $this->context->findElement('#password')->setValue($password);
         $this->context->getElementByText('Login', 'button')->click();
+
+        Assert::assertNotEquals('/login', $this->context->getSession()->getCurrentUrl());
     }
 }

--- a/src/lib/Core/Context/TimeContext.php
+++ b/src/lib/Core/Context/TimeContext.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Context;
+
+use Behat\Behat\Context\Context;
+
+class TimeContext implements Context
+{
+    /**
+     * @Given I wait :number seconds
+     */
+    public function iWait($number): void
+    {
+        sleep($number);
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/EZP-32103

Changes required by https://github.com/ezsystems/ezplatform-http-cache/pull/138

Couple of things here:
1) Added a new Context (TimeContext) that allows to wait a couple of seconds
2) Added a check that the login action is successful - we should be redirected after the login action to another page
3) As I've played with the Chromium a bit I've noticed that the format for HTTP headers is different - I've decided to include support for it in this PR 😄 
4) And the most important change: HTTP flushing. Here's a glimpse into our HTTP cache:
When we want to purge cache: https://github.com/ezsystems/ezplatform-http-cache/blob/master/src/PurgeClient/VarnishPurgeClient.php#L27
we call the `invalidateTags` method. We're using the `PURGEKEYS` way, so this code is relevant:
https://github.com/FriendsOfSymfony/FOSHttpCache/blob/master/src/ProxyClient/Varnish.php#L197-L205
The most important part: this part does not purge the cache 🙃  It simply pushes the request to purge the cache to a queue which is emptied (flushed) in InvalidationListener:
https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/src/EventListener/InvalidationListener.php

The cache is purged only when the requests are sent (the queue is flushed).

The InvalidationListener is an EventListener which listens to three events:
```
    public static function getSubscribedEvents()
    {
        return [
            KernelEvents::TERMINATE => 'onKernelTerminate',
            KernelEvents::EXCEPTION => 'onKernelException',
            ConsoleEvents::TERMINATE => 'onConsoleTerminate',
        ];
    }
```

Sadly for us, running our API from Behat triggers none of the above. That's why I've decided to flush the Queue manually when operations involving Content are executed - I'm not 100% happy with this (this can be really error prone, as it's easy to forget this). We might need to revisit it in the future if BehatBundle continues to grow - maybe it should be added as an AfterStep hook (but then it would trigger for all Steps, which might be an overkill/slight performance issue - something to assess in the future).
