### PR TITLE
Fixed installation type detection

### DIFF
--- a/src/lib/Core/Environment/EnvironmentConstants.php
+++ b/src/lib/Core/Environment/EnvironmentConstants.php
@@ -32,7 +32,7 @@ class EnvironmentConstants
 
     public static function isEnterprise(): bool
     {
-        return in_array(self::getInstallType(), [InstallType::ENTERPRISE, InstallType::ENTERPRISE_DEMO, InstallType::COMMERCE]);
+        return in_array(self::getInstallType(), [InstallType::CONTENT, InstallType::EXPERIENCE, InstallType::COMMERCE]);
     }
 
     private static function getProperEnvironment(int $installType)
@@ -41,7 +41,7 @@ class EnvironmentConstants
             case InstallType::OSS:
             case InstallType::CONTENT:
                 return new PlatformEnvironmentConstants();
-            case InstallType::ENTERPRISE:
+            case InstallType::EXPERIENCE:
             case InstallType::COMMERCE:
                 return new EnterpriseEnvironmentConstants();
             default:


### PR DESCRIPTION
Right now Enterprise tests are failing with:
```
Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Undefined class constant 'ENTERPRISE' in vendor/ezsystems/behatbundle/src/lib/Core/Environment/EnvironmentConstants.php:44
```

this PR fixes that.

Working proof: https://travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/210398845 (the first two jobs passed which wouldn't happen otherwise).