### PR TITLE
Fixed installation type detection for Flex

### DIFF
--- a/src/lib/Core/Environment/Environment.php
+++ b/src/lib/Core/Environment/Environment.php
@@ -14,6 +14,13 @@ class Environment
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface Symfony DI service container */
     private $serviceContainer;
 
+    /** @var array */
+    private $packageNameMap = [
+        'ezsystems/ezplatform' => InstallType::OSS,
+        'ezsystems/ezplatform-ee' => InstallType::EXPERIENCE,
+        'ezsystems/ezcommerce' => InstallType::COMMERCE,
+    ];
+
     /**
      * Environment constructor.
      *
@@ -57,17 +64,11 @@ class Environment
 
     private function isInstalledFromMetarepository($composerConfig): bool
     {
-        return property_exists($composerConfig, 'name');
+        return property_exists($composerConfig, 'name') && \in_array($composerConfig->name, \array_keys($this->packageNameMap));
     }
 
     private function getInstallTypeFromMetarepository($composerConfig): int
     {
-        $packageNameMap = [
-            'ezsystems/ezplatform' => InstallType::OSS,
-            'ezsystems/ezplatform-ee' => InstallType::EXPERIENCE,
-            'ezsystems/ezcommerce' => InstallType::COMMERCE,
-        ];
-
-        return $packageNameMap[$composerConfig->name];
+        return $this->packageNameMap[$composerConfig->name];
     }
 }

--- a/src/lib/Core/Environment/Environment.php
+++ b/src/lib/Core/Environment/Environment.php
@@ -15,7 +15,7 @@ class Environment
     private $serviceContainer;
 
     /** @var array */
-    private $packageNameMap = [
+    private $metarepositoryPackageNameMap = [
         'ezsystems/ezplatform' => InstallType::OSS,
         'ezsystems/ezplatform-ee' => InstallType::EXPERIENCE,
         'ezsystems/ezcommerce' => InstallType::COMMERCE,
@@ -64,11 +64,11 @@ class Environment
 
     private function isInstalledFromMetarepository($composerConfig): bool
     {
-        return property_exists($composerConfig, 'name') && \in_array($composerConfig->name, \array_keys($this->packageNameMap));
+        return property_exists($composerConfig, 'name') && \in_array($composerConfig->name, \array_keys($this->metarepositoryPackageNameMap));
     }
 
     private function getInstallTypeFromMetarepository($composerConfig): int
     {
-        return $this->packageNameMap[$composerConfig->name];
+        return $this->metarepositoryPackageNameMap[$composerConfig->name];
     }
 }


### PR DESCRIPTION
Right now tests running on Flex are failing with:
```
  ╳  Notice: Undefined index: ibexa/website-skeleton in vendor/ezsystems/behatbundle/src/lib/Core/Environment/Environment.php line 71
```

beucase the condition in `isInstalledFromMetarepository` is too broad.

Proof that it's working:
correctly running build in https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/211144857 🎉 