### PR TITLE
EZP-32259: Replaced "ezplatform" commands namespace with "ibexa"

### DIFF
--- a/src/bundle/Command/CreateExampleDataCommand.php
+++ b/src/bundle/Command/CreateExampleDataCommand.php
@@ -5,8 +5,10 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);
+
 namespace EzSystems\BehatBundle\Command;
 
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use EzSystems\Behat\Event\Events;
 use EzSystems\Behat\Event\InitialEvent;
 use Psr\Log\LoggerInterface;
@@ -21,9 +23,9 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class CreateExampleDataCommand extends Command
+class CreateExampleDataCommand extends Command implements BackwardCompatibleCommand
 {
-    public const NAME = 'ezplatform:tools:create-data';
+    public const NAME = 'ibexa:behat:create-data';
 
     /** @var EventDispatcherInterface */
     private $eventDispatcher;
@@ -51,6 +53,7 @@ class CreateExampleDataCommand extends Command
     protected function configure()
     {
         $this
+            ->setAliases(['ezplatform:tools:create-data'])
             ->addArgument('iterations', InputArgument::REQUIRED)
             ->addArgument('serializedTransitionData', InputArgument::REQUIRED);
     }
@@ -82,5 +85,13 @@ class CreateExampleDataCommand extends Command
     private function parseInputData(string $serializedTransitionEvent): InitialEvent
     {
         return $this->serializer->deserialize(base64_decode($serializedTransitionEvent), InitialEvent::class, 'json');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ezplatform:tools:create-data'];
     }
 }

--- a/src/bundle/Command/CreateExampleDataManagerCommand.php
+++ b/src/bundle/Command/CreateExampleDataManagerCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\BehatBundle\Command;
 
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use EzSystems\Behat\Event\InitialEvent;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,7 +21,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Yaml\Yaml;
 
-class CreateExampleDataManagerCommand extends Command
+class CreateExampleDataManagerCommand extends Command implements BackwardCompatibleCommand
 {
     private const BATCH_SIZE = 100;
 
@@ -41,13 +42,19 @@ class CreateExampleDataManagerCommand extends Command
 
     public function __construct(string $env, string $projectDir)
     {
-        parent::__construct('ezplatform:tools:generate-items');
+        parent::__construct('ibexa:behat:generate-items');
+
         $encoders = [new JsonEncoder()];
         $normalizers = [new ObjectNormalizer()];
         $this->serializer = new Serializer($normalizers, $encoders);
         $this->env = $env;
         $this->projectDir = $projectDir;
         $this->stopwatch = new Stopwatch();
+    }
+
+    protected function configure(): void
+    {
+        $this->setAliases(['ezplatform:tools:generate-items']);
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -144,5 +151,13 @@ class CreateExampleDataManagerCommand extends Command
     private function serialize(InitialEvent $eventData): string
     {
         return base64_encode($this->serializer->serialize($eventData, 'json'));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ezplatform:tools:generate-items'];
     }
 }

--- a/src/bundle/Command/CreateLanguageCommand.php
+++ b/src/bundle/Command/CreateLanguageCommand.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\BehatBundle\Command;
 
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\UserService;
@@ -14,7 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateLanguageCommand extends Command
+class CreateLanguageCommand extends Command implements BackwardCompatibleCommand
 {
     /** @var \eZ\Publish\API\Repository\LanguageService */
     private $languageService;
@@ -34,13 +35,14 @@ class CreateLanguageCommand extends Command
         $this->userService = $userService;
         $this->permissionResolver = $permissionResolver;
 
-        parent::__construct(null);
+        parent::__construct();
     }
 
     protected function configure()
     {
         $this
-            ->setName('ez:behat:create-language')
+            ->setName('ibexa:behat:create-language')
+            ->setAliases(['ez:behat:create-language'])
             ->setDescription('Create a Language')
             ->addArgument('language-code', InputArgument::REQUIRED)
             ->addArgument('language-name', InputArgument::OPTIONAL, 'Language name', '')
@@ -68,5 +70,13 @@ class CreateLanguageCommand extends Command
         $this->languageService->createLanguage($languageCreateStruct);
 
         return 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ez:behat:create-language'];
     }
 }

--- a/src/bundle/Command/GetPullRequestDataCommand.php
+++ b/src/bundle/Command/GetPullRequestDataCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\BehatBundle\Command;
 
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,7 +19,7 @@ use Http\Discovery\HttpClientDiscovery;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Discovery\MessageFactoryDiscovery;
 
-class GetPullRequestDataCommand extends Command
+class GetPullRequestDataCommand extends Command implements BackwardCompatibleCommand
 {
     /** @var string */
     private $token;
@@ -40,7 +41,8 @@ class GetPullRequestDataCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ezplatform:tools:get-pull-request-data')
+            ->setName('ibexa:behat:get-pull-request-data')
+            ->setAliases(['ezplatform:tools:get-pull-request-data'])
             ->setDescription('Get data about a GitHub Pull Request')
             ->addArgument(
                 'pull-request-url',
@@ -179,5 +181,13 @@ If you have configured Composer with your token it can be obtained by running 'c
         }
 
         return $response;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ezplatform:tools:get-pull-request-data'];
     }
 }

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -14,9 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 
 class TestSiteaccessCommand extends Command implements BackwardCompatibleCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'ibexa:behat:test-siteaccess';
-
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
     private $siteaccess;
 
@@ -33,8 +30,8 @@ class TestSiteaccessCommand extends Command implements BackwardCompatibleCommand
     protected function configure()
     {
         $this
-            ->setName(self::$defaultName)
-            ->setAliases(['ez:behat:siteaccess'])
+            ->setName('ibexa:behat:test-siteaccess')
+            ->setAliases($this->getDeprecatedAliases())
             ->setDescription('Outputs the name of the active siteaccess');
     }
 

--- a/src/bundle/Command/TestSiteaccessCommand.php
+++ b/src/bundle/Command/TestSiteaccessCommand.php
@@ -6,15 +6,16 @@
  */
 namespace EzSystems\BehatBundle\Command;
 
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 
-class TestSiteaccessCommand extends Command
+class TestSiteaccessCommand extends Command implements BackwardCompatibleCommand
 {
     /** @var string|null */
-    protected static $defaultName = 'ez:behat:siteaccess';
+    protected static $defaultName = 'ibexa:behat:test-siteaccess';
 
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
     private $siteaccess;
@@ -33,6 +34,7 @@ class TestSiteaccessCommand extends Command
     {
         $this
             ->setName(self::$defaultName)
+            ->setAliases(['ez:behat:siteaccess'])
             ->setDescription('Outputs the name of the active siteaccess');
     }
 
@@ -41,5 +43,13 @@ class TestSiteaccessCommand extends Command
         $output->writeln($this->siteaccess->name);
 
         return 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ez:behat:siteaccess'];
     }
 }


### PR DESCRIPTION
> JIRA: [EZP-32259](https://jira.ez.no/browse/EZP-32259)

### Description

Replaced "ezplatform" commands namespace with "ibexa".

<table><tbody><tr><td><strong>Old name</strong></td><td><strong>New name</strong></td></tr><tr><td><code>ezplatform:tools:create-data</code></td><td><code>ibexa:behat:create-data</code></td></tr><tr><td><code>ezplatform:tools:generate-items</code></td><td><code>ibexa:behat:generate-items</code></td></tr><tr><td><code>ez:behat:create-language</code></td><td><code>ibexa:behat:create-language</code></td></tr><tr><td><code>ezplatform:tools:get-pull-request-data</code></td><td><code>ibexa:behat:get-pull-request-data</code></td></tr><tr><td><code>ez:behat:siteaccess</code></td><td><code>ibexa:behat:test-siteaccess</code></td></tr></tbody></table>

Requires ezsystems/ezplatform-kernel#153.

## Checklist

*   [x] Code follows the code style of this project (use `$ composer fix-cs`).
*   [x] Change requires a change to the documentation.
*   [x] Code is ready for a review.