### PR TITLE
Updated deprecated command name

### DIFF
--- a/bin/.travis/trigger_ci.sh
+++ b/bin/.travis/trigger_ci.sh
@@ -50,7 +50,7 @@ echo 'Adding dependencies to Composer...'
 # Step 2: Parse data from the Pull Request
 for i in "${prLinks[@]}"
 do
-  read -r -a VALUES <<< "$(php bin/console ezplatform:tools:get-pull-request-data $i $GITHUB_OAUTH_TOKEN)"
+  read -r -a VALUES <<< "$(php bin/console ibexa:behat:get-pull-request-data $i $GITHUB_OAUTH_TOKEN)"
 
   REPOSITORY_URLS+=("${VALUES[0]}")
 


### PR DESCRIPTION
`ezplatform:tools:get-pull-request-data` is deprecated, we should use `ibexa:behat:get-pull-request-data`.

In this case it's not only an issue of fixing a deprecation - we're parsing the command output directly, so the deprecation warning is parsed as well and the script fails to detect the correct branch to use.