### PR TITLE
Made GitHub token optional for getting PR data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 composer.lock
 composer.phar
-
+.phpunit.result.cache

--- a/src/bundle/Command/GetPullRequestDataCommand.php
+++ b/src/bundle/Command/GetPullRequestDataCommand.php
@@ -48,7 +48,7 @@ class GetPullRequestDataCommand extends Command
                 'GitHub Pull Request URL')
             ->addArgument(
                 'token',
-                InputArgument::REQUIRED,
+                InputArgument::OPTIONAL,
                 'GitHub OAuth token')
             ->setHelp("This command outputs data in given order:
             - repository URL
@@ -163,9 +163,12 @@ If you have configured Composer with your token it can be obtained by running 'c
     {
         $headers = [
             'User-Agent' => 'ezrobot',
-            'Authorization' => sprintf('token %s', $this->token),
             'Accept' => $acceptFormat,
         ];
+
+        if ($this->token) {
+            $headers['Authorization'] = sprintf('token %s', $this->token);
+        }
 
         $request = new Request('GET', $requestUrl, $headers);
         $response = $this->httpClient->sendRequest($request);

--- a/tests/Command/GetPullRequestDataCommandTest.php
+++ b/tests/Command/GetPullRequestDataCommandTest.php
@@ -16,8 +16,6 @@ class GetPullRequestDataCommandTest extends TestCase
 
     private const EXAMPLE_GITHUB_PR_LINK = 'https://github.com/ezsystems/BehatBundle/pull/99';
 
-    private const EXAMPLE_GITHUB_TOKEN = 'd0285ed5c8644f30547572ead2ed897431c1fc09';
-
     public function setUp(): void
     {
         $this->commandTester = new CommandTester(new GetPullRequestDataCommand());
@@ -30,7 +28,6 @@ class GetPullRequestDataCommandTest extends TestCase
 
         $this->commandTester->execute([
             'pull-request-url' => self::EXAMPLE_GITHUB_PR_LINK,
-            'token' => self::EXAMPLE_GITHUB_TOKEN,
         ]);
 
         $this->assertEquals($expectedOutput, $this->commandTester->getDisplay());


### PR DESCRIPTION
Backporting the unit tests fix, as promised in https://github.com/ezsystems/BehatBundle/pull/174