### PR TITLE
Changed how installation type is detected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",
         "symfony/property-access": "^5.0",
-        "symfony/yaml": "^5.0",
-        "ibexa/post-install": "^1.0"
+        "symfony/yaml": "^5.0"
     },
     "require-dev": {
         "ibexa/ci-scripts": "^0.1@dev",

--- a/src/bundle/DependencyInjection/eZBehatExtension.php
+++ b/src/bundle/DependencyInjection/eZBehatExtension.php
@@ -10,9 +10,10 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Ibexa\Platform\PostInstall\IbexaProductVersion;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Loader;
+use EzSystems\Behat\Core\Environment\Environment;
+use EzSystems\Behat\Core\Environment\InstallType;
 
 class eZBehatExtension extends Extension implements PrependExtensionInterface, CompilerPassInterface
 {
@@ -33,8 +34,10 @@ class eZBehatExtension extends Extension implements PrependExtensionInterface, C
     {
         $container->setParameter(self::OVERRIDE_CONFIGURATION, true);
 
-        $product = IbexaProductVersion::getInstalledProduct();
-        if ($product !== 'ibexa/oss') {
+        $env = new Environment($container);
+        $installType = $env->getInstallType();
+
+        if (\in_array($installType, [InstallType::CONTENT, InstallType::EXPERIENCE, InstallType::COMMERCE])) {
             $container->setParameter(self::ENABLE_ENTERPRISE_SERVICES, true);
         }
     }


### PR DESCRIPTION
Changed how the installation type (OSS, Content, Experience, Commerce) is detected:
the solution using post-install package works for Flex installations, but breaks for metarepository installs.

This approach should work for both of them.

Failing build:
https://travis-ci.com/github/ezsystems/ezplatform/jobs/489613579
```
PHP Fatal error:  Uncaught TypeError: Return value of Ibexa\Platform\PostInstall\IbexaProductVersion::getInstalledProduct() must be of the type string, bool returned in /var/www/vendor/ibexa/post-install/src/lib/IbexaProductVersion.php:44

Stack trace:

#0 /var/www/vendor/ezsystems/behatbundle/src/bundle/DependencyInjection/eZBehatExtension.php(36): Ibexa\Platform\PostInstall\IbexaProductVersion::getInstalledProduct()
#1 /var/www/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(45): EzSystems\BehatBundle\DependencyInjection\eZBehatExtension->prepend(Object(Symfony\Component\DependencyInjection\ContainerBuilder))
#2 /var/www/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php(39): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process(Object(Symfony\Component\DependencyInjection\ContainerBuilder))
#3 /var/www/vendor/symfony/dependency-injection/Compiler/Compiler.php(91): Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionCo in /var/www/vendor/ibexa/post-install/src/lib/IbexaProductVersion.php on line 44
```