### PR TITLE
EZEE-3506: Added data for SiteFactory setup

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,7 +3,7 @@
 return  EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
     ->setFinder(
         PhpCsFixer\Finder::create()
-            ->in(__DIR__ . '/src')
+            ->in([__DIR__ . '/src', __DIR__ . '/tests'])
             ->files()->name('*.php')
     )
 ;

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -1,5 +1,6 @@
 imports:
     - behat_ibexa_content.yaml
     - vendor/ezsystems/ezplatform-page-builder/behat_suites.yml
+    - vendor/ezsystems/ezplatform-site-factory/behat_suites.yml
     - vendor/ezsystems/ezplatform-form-builder/behat_suites.yml
     - vendor/ezsystems/ezplatform-page-fieldtype/behat_suites.yml

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         }
     },
     "scripts": {
-        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
+        "test": "phpunit"
     },
     "extra": {
         "_ezplatform_branch_for_behat_tests": "master",

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -75,3 +75,10 @@ services:
             - { name: console.command }
 
     EzSystems\Behat\QueryType\FoldersUnderMediaQueryType: ~
+
+    EzSystems\Behat\Core\Configuration\ConfigurationEditor: ~
+
+    EzSystems\Behat\Core\Configuration\LocationAwareConfigurationEditor:
+        decorates: EzSystems\Behat\Core\Configuration\ConfigurationEditor
+
+    EzSystems\Behat\Core\Configuration\ConfigurationEditorInterface: '@EzSystems\Behat\Core\Configuration\LocationAwareConfigurationEditor'

--- a/src/lib/API/Facade/ContentFacade.php
+++ b/src/lib/API/Facade/ContentFacade.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use EzSystems\Behat\API\ContentData\ContentDataProvider;
 use FOS\HttpCacheBundle\CacheManager;
@@ -97,12 +98,15 @@ class ContentFacade
 
     public function getContentByLocationURL($locationURL): Content
     {
+        return $this->getLocationByLocationURL($locationURL)->getContent();
+    }
+
+    public function getLocationByLocationURL($locationURL): Location
+    {
         $urlAlias = $this->urlAliasService->lookup($locationURL);
         Assert::assertEquals(URLAlias::LOCATION, $urlAlias->type);
 
-        return $this->locationService
-            ->loadLocation($urlAlias->destination)
-            ->getContent();
+        return $this->locationService->loadLocation($urlAlias->destination);
     }
 
     private function flushHTTPcache(): void

--- a/src/lib/Core/Configuration/ConfigurationEditor.php
+++ b/src/lib/Core/Configuration/ConfigurationEditor.php
@@ -9,7 +9,7 @@ namespace EzSystems\Behat\Core\Configuration;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Yaml\Yaml;
 
-class ConfigurationEditor
+class ConfigurationEditor implements ConfigurationEditorInterface
 {
     /**
      * Appends given value under key, extending existing settings.

--- a/src/lib/Core/Configuration/ConfigurationEditorInterface.php
+++ b/src/lib/Core/Configuration/ConfigurationEditorInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Core\Configuration;
+
+interface ConfigurationEditorInterface
+{
+    /**
+     * Appends given value under key, extending existing settings.
+     *
+     * @param $config
+     * @param string $key 'key' or 'nested.key'
+     * @param string|array $value
+     *
+     * @return mixed YAML config
+     */
+    public function append($config, string $key, $value);
+
+    /**
+     * Sets given value under key. Existing settings are overwritten.
+     *
+     * @param $config
+     * @param string $key 'key' or 'nested.key'
+     * @param string|array $value
+     *
+     * @return mixed YAML config
+     */
+    public function set($config, string $key, $value);
+
+    public function get($config, string $key);
+
+    /**
+     * @param string $filePath
+     *
+     * @return mixed YAML config
+     */
+    public function getConfigFromFile(string $filePath);
+
+    /**
+     * @param $filePath
+     * @param $config
+     */
+    public function saveConfigToFile($filePath, $config): void;
+}

--- a/src/lib/Core/Context/FileContext.php
+++ b/src/lib/Core/Context/FileContext.php
@@ -7,6 +7,7 @@
 namespace EzSystems\Behat\Core\Context;
 
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
 
 class FileContext implements Context
 {
@@ -23,7 +24,7 @@ class FileContext implements Context
     /**
      * @Given I create a file :path with content from :sourceFile
      */
-    public function createFile($path, $sourceFile): void
+    public function createFileFromSourceFile($path, $sourceFile): void
     {
         $content = file_get_contents(sprintf('%s/%s/%s', $this->projectDirectory, self::SOURCE_FILE_DIRECTORY, $sourceFile));
         $destinationPath = sprintf('%s/%s', $this->projectDirectory, $path);
@@ -38,6 +39,16 @@ class FileContext implements Context
     {
         $content = file_get_contents(sprintf('%s/%s/%s', $this->projectDirectory, self::SOURCE_FILE_DIRECTORY, $sourceFile));
         file_put_contents($file, $content, FILE_APPEND | LOCK_EX);
+    }
+
+    /**
+     * @Given I create a file :path with contents
+     */
+    public function createFileFromContent(string $path, PyStringNode $fileContent): void
+    {
+        $destinationPath = sprintf('%s/%s', $this->projectDirectory, $path);
+        $this->createDirectoryStructure($destinationPath);
+        file_put_contents($destinationPath, $fileContent->getRaw());
     }
 
     private function createDirectoryStructure($destinationPath): void

--- a/src/lib/Data/Templates/SiteFactory/pagelayout1.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout1.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template1</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout10.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout10.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template10</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout11.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout11.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template11</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout12.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout12.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template12</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout13.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout13.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template13</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout14.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout14.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template14</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout15.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout15.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template15</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout16.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout16.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template16</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout17.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout17.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template17</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout18.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout18.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template18</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout19.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout19.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template19</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout2.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout2.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template2</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout20.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout20.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template20</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout3.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout3.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template3</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout4.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout4.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template4</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout5.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout5.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template5</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout6.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout6.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template6</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout7.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout7.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template7</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout8.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout8.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template8</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/src/lib/Data/Templates/SiteFactory/pagelayout9.html.twig
+++ b/src/lib/Data/Templates/SiteFactory/pagelayout9.html.twig
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <link rel="icon" type="image/x-icon" href="{{ asset('bundles/ezplatformadminui/img/favicon.ico') }}" />
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+</head>
+<body>
+
+<div id="template">SiteFactory_template9</div>
+
+{% block test %}
+{% endblock %}
+
+<div id="render">
+Item: 
+{{ ez_render(content) }}
+</div>
+
+<div id="renderESI">
+Item with ESI: 
+{{ ez_render(content, { method: "esi" }) }} 
+</div>
+
+<div id="siteName">
+Site:
+{{ ez_render(ezplatform.rootLocation)}}
+</div>
+
+</body>
+</html>
+
+

--- a/tests/Core/Behat/ArgumentParserTest.php
+++ b/tests/Core/Behat/ArgumentParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -39,5 +40,4 @@ class ArgumentParserTest extends TestCase
             ['New Folder Long Name', '/New-Folder-Long-Name'],
         ];
     }
-
 }

--- a/tests/Core/Configuration/ConfigurationEditorTest.php
+++ b/tests/Core/Configuration/ConfigurationEditorTest.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\Behat\Test\Core\Configuration;
 
 use EzSystems\Behat\Core\Configuration\ConfigurationEditor;
@@ -89,7 +89,7 @@ class ConfigurationEditorTest extends TestCase
 
         $config = $configurationEditor->append($initialConfig, 'testKey.testSection', ['testValue1', 'testValue2']);
 
-        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1','testValue2']]], $config);
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1', 'testValue2']]], $config);
     }
 
     public function testCanAddAnotherValueWithConfigurationEditor()
@@ -100,7 +100,7 @@ class ConfigurationEditorTest extends TestCase
         $config = $configurationEditor->append($initialConfig, 'testKey', 'testValue1');
         $config = $configurationEditor->append($config, 'testKey', 'testValue2');
 
-        Assert::assertEquals(['testKey' => ['testValue1','testValue2']], $config);
+        Assert::assertEquals(['testKey' => ['testValue1', 'testValue2']], $config);
     }
 
     public function testCanAddNestedValueWithConfigurationEditor()
@@ -160,7 +160,7 @@ class ConfigurationEditorTest extends TestCase
         $configurationEditor = new ConfigurationEditor();
         $initialConfig = ['testKey' => ['initialValue1', 'initialValue2']];
 
-        $config = $configurationEditor->set($initialConfig, 'testKey','testValue');
+        $config = $configurationEditor->set($initialConfig, 'testKey', 'testValue');
 
         Assert::assertEquals(['testKey' => 'testValue'], $config);
     }
@@ -202,7 +202,7 @@ class ConfigurationEditorTest extends TestCase
 
         $config = $configurationEditor->set($initialConfig, 'testKey.testSection', ['testValue1', 'testValue2']);
 
-        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1','testValue2']]], $config);
+        Assert::assertEquals(['testKey' => ['initialValue', 'testSection' => ['testValue1', 'testValue2']]], $config);
     }
 
     public function testCanSetAnotherValueWithConfigurationEditor()

--- a/tests/Core/Configuration/LocationAwareConfigurationEditorTest.php
+++ b/tests/Core/Configuration/LocationAwareConfigurationEditorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\Behat\Test\Core\Configuration;
+
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\Behat\API\Facade\ContentFacade;
+use EzSystems\Behat\Core\Configuration\ConfigurationEditor;
+use EzSystems\Behat\Core\Configuration\LocationAwareConfigurationEditor;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class LocationAwareConfigurationEditorTest extends TestCase
+{
+    private $locationAwareConfigurationEditor;
+
+    public function setUp(): void
+    {
+        $contentFacadeStub = $this->createStub(ContentFacade::class);
+        $contentFacadeStub
+            ->method('getLocationByLocationURL')
+            ->willReturnMap(
+                [
+                    ['Home', new Location(['id' => 2])],
+                    ['Users', new Location(['id' => 3])],
+                    ['Home/Folder', new Location(['id' => 4])],
+                    ['Home/Folder1/Folder2', new Location(['id' => 5])],
+                ]
+            );
+
+        $this->locationAwareConfigurationEditor = new LocationAwareConfigurationEditor(
+            new ConfigurationEditor(),
+            $contentFacadeStub
+        );
+    }
+
+    public function testReplacesSingleValue()
+    {
+        $initialConfig = ['testKey' => '%location_id(Home)%'];
+
+        $value = $this->locationAwareConfigurationEditor->get($initialConfig, 'testKey');
+
+        Assert::assertEquals(2, $value);
+    }
+
+    public function testReplacesMultipleValues()
+    {
+        $initialConfig = ['testKey' => ['%location_id(Home)%', '%location_id(Users)%']];
+
+        $value = $this->locationAwareConfigurationEditor->get($initialConfig, 'testKey');
+
+        Assert::assertEquals([2, 3], $value);
+    }
+
+    public function testReplacesValueWhenSetIsUsed()
+    {
+        $initialConfig = ['testKey' => ['%location_id(Home)%']];
+
+        $config = $this->locationAwareConfigurationEditor->set($initialConfig, 'testKey.testSection', ['testValue1', '%location_id(Users)%']);
+
+        Assert::assertEquals(['testKey' => [2, 'testSection' => ['testValue1', 3]]], $config);
+    }
+
+    public function testReplacesValueWhenAppendIsUsed()
+    {
+        $initialConfig = ['testKey' => '%location_id(Home)%'];
+
+        $config = $this->locationAwareConfigurationEditor->append($initialConfig, 'testKey', '%location_id(Home/Folder1/Folder2)%');
+
+        Assert::assertEquals(['testKey' => [2, 5]], $config);
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/EZEE-3506

Required by:
https://github.com/ezsystems/ezplatform-site-factory/pull/116

Things done:
1) ConfigurationEditor is now a bit smarter:
you can use a special `%location_id(itemLocationURL)%` function which will be resolved to the location_id of the specified item.

Example:
```
  Scenario Outline: Configure Site Factory siteaccesses
    Given I append configuration to "ez_platform_site_factory.templates" in "config/packages/ezplatform_site_factory.yaml"
    """
          <template_id>:
            siteaccess_group: <sa_group>
            name: <template_name>
            thumbnail: https://placekitten.com/500/500
            site_skeleton_id: "%location_id(Site-skeletons/MySiteSkeleton)%"
    """
```

The `site_skeleton_id` value will be set to the Location ID of the /Site-skeletons/MySiteSkeleton item. No need for hardcoding IDs 😄 

2) Added Twig templates required by https://github.com/ezsystems/ezplatform-site-factory/pull/116 (more description there).
