### PR TITLE
IBX-116: More integration tests for HTTP cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/config": "^5.0",
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
+        "symfony/stopwatch": "^5.2",
         "symfony/http-kernel": "^5.0",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0"

--- a/src/bundle/Controller/RenderController.php
+++ b/src/bundle/Controller/RenderController.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\BehatBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\API\Repository\ContentService;
+
+class RenderController extends Controller
+{
+    private $contentService;
+
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    public function embedAction(ContentView $view): ContentView
+    {
+        $destinationContentId = $view->getContent()->getFieldValue('relation')->destinationContentId;
+        $content = $this->contentService->loadContent($destinationContentId);
+        $view->addParameters(['embeddedItem' => $content]);
+
+        return $view;
+    }
+
+    public function longAction(ContentView $view): ContentView
+    {
+        sleep(5);
+
+        return $view;
+    }
+}

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -2,6 +2,7 @@ imports:
     - { resource: services/fieldtype_data_providers.yaml }
     - { resource: services/limitation_parsers.yaml }
     - { resource: services/contexts.yaml }
+    - { resource: services/controllers.yaml }
 
 services:
     _defaults:
@@ -47,10 +48,6 @@ services:
         public: true
         arguments:
             - '@EzSystems\Behat\API\Facade\RoleFacade'
-
-    ezbehatbundle.controller.exception:
-        class: EzSystems\BehatBundle\Controller\ExceptionController
-        public: true
 
     EzSystems\BehatBundle\Command\CreateLanguageCommand:
         arguments:

--- a/src/bundle/Resources/config/services/contexts.yaml
+++ b/src/bundle/Resources/config/services/contexts.yaml
@@ -75,3 +75,5 @@ services:
             $logger: '@logger'
             $kernel: '@kernel'
             $container: '@service_container'
+
+    EzSystems\Behat\Core\Context\TimeContext: ~

--- a/src/bundle/Resources/config/services/controllers.yaml
+++ b/src/bundle/Resources/config/services/controllers.yaml
@@ -1,0 +1,11 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  ezbehatbundle.controller.exception:
+    class: EzSystems\BehatBundle\Controller\ExceptionController
+    public: true
+
+  EzSystems\BehatBundle\Controller\RenderController: ~

--- a/src/bundle/Resources/views/tests/cache/embed_esi.html.twig
+++ b/src/bundle/Resources/views/tests/cache/embed_esi.html.twig
@@ -1,0 +1,3 @@
+{{ ez_render(content) }}
+
+{{ ez_render(embeddedItem, {'viewType': 'line', 'method': 'esi'}) }}

--- a/src/bundle/Resources/views/tests/cache/embed_no_esi.html.twig
+++ b/src/bundle/Resources/views/tests/cache/embed_no_esi.html.twig
@@ -1,0 +1,3 @@
+{{ ez_render(content) }}
+
+{{ ez_render(embeddedItem, {'viewType': 'line'}) }}

--- a/src/bundle/Resources/views/tests/cache/embedded.html.twig
+++ b/src/bundle/Resources/views/tests/cache/embedded.html.twig
@@ -1,0 +1,1 @@
+{{ ez_render(content) }}

--- a/src/lib/Browser/Context/BrowserContext.php
+++ b/src/lib/Browser/Context/BrowserContext.php
@@ -353,6 +353,20 @@ class BrowserContext extends MinkContext
         }
     }
 
+    /**
+     * @Given response headers match pattern
+     */
+    public function responseHeadersMatchPattern(TableNode $expectedHeadersData): void
+    {
+        $responseHeaders = $this->getSession()->getDriver()->getResponseHeaders();
+
+        foreach ($expectedHeadersData->getHash() as $row) {
+            $expectedValuePattern = $row['Pattern'];
+            $actualValue = $this->getHeaderValue($responseHeaders, $row['Header']);
+            Assert::assertEquals(1, preg_match($expectedValuePattern, $actualValue));
+        }
+    }
+
     private function getHeaderValue($responseHeaders, $header): string
     {
         if ($this->getSession()->getDriver() instanceof ChromeDriver) {

--- a/src/lib/Browser/Context/FrontendContext.php
+++ b/src/lib/Browser/Context/FrontendContext.php
@@ -39,6 +39,7 @@ class FrontendContext implements Context
     /**
      * @Given I am viewing the pages on siteaccess :siteaccess as :username
      * @Given I am viewing the pages on siteaccess :siteaccess as :username :password
+     * @Given I am viewing the pages on siteaccess :siteaccess as :username with password :password
      */
     public function iAmViewingThePagesAsUserOnSiteaccess(string $siteaccess, string $username, string $password = null)
     {

--- a/src/lib/Core/Context/TimeContext.php
+++ b/src/lib/Core/Context/TimeContext.php
@@ -7,14 +7,55 @@
 namespace EzSystems\Behat\Core\Context;
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 class TimeContext implements Context
 {
+    private $stopwatch;
+
+    public function __construct(Stopwatch $stopwatch)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+
     /**
      * @Given I wait :number seconds
      */
     public function iWait($number): void
     {
         sleep($number);
+    }
+
+    /**
+     * @Given I start measuring time
+     */
+    public function iStartMeasuingTime(): void
+    {
+        $this->stopwatch->start('event');
+    }
+
+    /**
+     * @Given the action took no longer than :seconds seconds
+     */
+    public function actionTookNoLongerThan(string $maxDuration): void
+    {
+        $this->stopwatch->stop('event');
+        $actualDuration = $this->stopwatch->getEvent('event')->getDuration() / 1000;
+        $this->stopwatch->reset();
+
+        Assert::assertLessThanOrEqual($maxDuration, $actualDuration);
+    }
+
+    /**
+     * @Given the action took longer than :seconds seconds
+     */
+    public function actionTookLongerThan(string $maxDuration): void
+    {
+        $this->stopwatch->stop('event');
+        $actualDuration = $this->stopwatch->getEvent('event')->getDuration() / 1000;
+        $this->stopwatch->reset();
+
+        Assert::assertGreaterThan($maxDuration, $actualDuration);
     }
 }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-116

Required by: https://github.com/ezsystems/ezplatform-http-cache/pull/149

This PR adds two things:
1) More time-related steps to TimeContext - it's possible to measure time of execution of steps by enclosing them between `I start measuring time` and one of `the action took no longer than N seconds` or `the action took longer than N seconds`.
2) Twig templates and Controllers used to enrich the default ViewController (see related PR and https://doc.ibexa.co/en/latest/guide/controllers/#enriching-viewcontroller-with-a-custom-controller for more info how it works)

The templates and Controller allow us to render a Content Item and an embedded Content item in it (using the rendering method that we choose - "standard" and "ESI" is used here). The long action with sleep is used to simulate a slow rendering of an embedded item - this allows us to make sure that only the first reload is slow and the next ones are fast (coming from HTTP cache).
