### PR TITLE
[Composer] Allowed to install PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "guzzlehttp/psr7": "^1.6.1",
         "liuggio/fastest": "^1.7",
         "php-http/client-common": "^2.1",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "symfony/config": "^5.0",
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",


### PR DESCRIPTION
Travis fails to install the correct version of BehatBundle on Travis, it installs 8.0.0-beta4:
```
./composer.json has been updated
Running composer update ezsystems/behatbundle
Loading composer repositories with package information
Updating dependencies
Lock file operations: 10 installs, 0 updates, 0 removals
  - Locking behat/behat (dev-master 689f1e4)
  - Locking behat/gherkin (v4.8.0)
  - Locking behat/mink-selenium2-driver (dev-master 4a4d1af)
  - Locking behat/transliterator (v1.3.0)
  - Locking ezsystems/behatbundle (v8.0.0-beta4)
  - Locking friends-of-behat/mink (v1.9.0)
  - Locking friends-of-behat/mink-extension (v2.5.0)
  - Locking friends-of-behat/symfony-extension (dev-master 7d02274)
  - Locking fzaninotto/faker (dev-master 5ffe7db)
  - Locking instaclick/php-webdriver (1.x-dev b5f330e)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 10 installs, 0 updates, 0 removals
  - Downloading ezsystems/behatbundle (v8.0.0-beta4)
```

The correct version cannot be installed because it conflicts on phpunit:
```
MacBook-Pro:v3 mareknocon$ composer require --dev ezsystems/behatbundle:^8.3.x-dev --no-scripts
./composer.json has been updated
Running composer update ezsystems/behatbundle
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires ezsystems/behatbundle ^8.3.x-dev -> satisfiable by ezsystems/behatbundle[8.3.x-dev].
    - ezsystems/behatbundle 8.3.x-dev requires phpunit/phpunit ^8.5 -> found phpunit/phpunit[8.5.0, ..., 8.5.x-dev] but it conflicts with your root composer.json require (^9.5).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

This PR allows us to install PHPUnit 9 with BehatBundle.