### PR TITLE
[Behat] IBX-160 - added configuration for 'sesspecificationstype' field in Product content type

### DIFF
--- a/src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
+++ b/src/lib/API/ContentData/FieldTypeData/SelectionDataProvider.php
@@ -31,6 +31,9 @@ class SelectionDataProvider implements FieldTypeDataProviderInterface
 
         $isMultiple = $fieldSettings['isMultiple'];
         $availableOptions = $fieldSettings['options'];
+        if (empty($availableOptions)) {
+            return new Value();
+        }
 
         $numberOfOptionsToPick = $isMultiple ? random_int(1, count($availableOptions)) : 1;
         $randomOptionIndices = array_rand(range(0, count($availableOptions) - 1), $numberOfOptionsToPick);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          |  https://issues.ibexa.co/browse/IBX-160
| **Type**                                   | tests
| **Target version** | 8.3
| **BC breaks**                          | no
| **Tests pass**                          | no
| **Doc needed**                       | no

This PR requires https://github.com/ezsystems/ezcommerce-shop/pull/319

This PR adds configuration for 'sesspecificationstype' field which occurs in ezlandingpage field - if 'sesspecificationstype' field is empty (and usually it is, as it is not mandatory) a whole JSON is injected there (this is done now in https://github.com/ezsystems/ezcommerce-shop/pull/319 https://github.com/ezsystems/ezcommerce-shop/pull/319/files#diff-2101e8b0403515dfae85e3b0907c031c6b575991e86c1b2986c60f68f5683a6b)