### PR TITLE
IBX-580: deleted location limitation role

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -45,6 +45,7 @@ setup:
                 - EzSystems\BehatBundle\Context\Object\RoleContext
                 - EzSystems\BehatBundle\Context\Object\ContentContext
                 - EzSystems\BehatBundle\Context\Object\ContentTypeContext
+                - EzSystems\BehatBundle\Context\Object\TrashContext
         URIElement:
             paths:
                 - '%paths.base%/vendor/ezsystems/behatbundle/EzSystems/BehatBundle/features/setup/siteaccessMatcher/URIElement.feature'

--- a/features/personas/deleted_location_limitation.feature
+++ b/features/personas/deleted_location_limitation.feature
@@ -1,0 +1,12 @@
+Feature: Role with location limitation to deleted location
+
+  @admin @setup @deletedLocation
+  Scenario: Create a Role and assign policy with limitation pointing to deleted location
+    Given I create "folder" Content items in root in "eng-GB"
+      | name            | short_name      |
+      | DeletedLocation | DeletedLocation |
+    And I create a role "DeletedLocationRole"
+    And I add policy "content" "read" to "DeletedLocationRole" with limitations
+      | limitationType | limitationValue  |
+      | Location       | /DeletedLocation |
+    And I send "/DeletedLocation" to the Trash


### PR DESCRIPTION
**JIRA**: https://issues.ibexa.co/browse/IBX-580

Behatbundle part of the test checking whether it is possible to access a role that has a policy with a location limitation pointing to a location that has been deleted.

Related PRs:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1799
https://github.com/ezsystems/ezplatform-page-builder/pull/785