### PR TITLE
Changed Router to always prefix routes with slash

### DIFF
--- a/src/lib/Browser/Routing/Router.php
+++ b/src/lib/Browser/Routing/Router.php
@@ -28,6 +28,8 @@ final class Router
 
     public function reverseMatchRoute(string $siteAccessName, string $route): string
     {
+        $route = strpos($route, '/') === 0 ? $route : sprintf('/%s', $route);
+
         $matcher = $this->router->matchByName($siteAccessName)->matcher;
         $matcher->setRequest(new SimplifiedRequest(['scheme' => 'http', 'host' => $this->minkParameters['base_url'], 'pathinfo' => $route]));
         $request = $matcher->reverseMatch($siteAccessName)->getRequest();


### PR DESCRIPTION
Routes returned from the `getRoute` method will be automatically prefixed with a forward slash if they do not contain it already.

The slash prefix is required by tests running using Map\Host matcher.

Required by:
https://github.com/ezsystems/ezplatform-page-builder/pull/787