### PR TITLE
Fixed ChildElementTextCriterion error message

### DIFF
--- a/src/lib/Browser/Element/Criterion/ChildElementTextCriterion.php
+++ b/src/lib/Browser/Element/Criterion/ChildElementTextCriterion.php
@@ -44,7 +44,7 @@ class ChildElementTextCriterion implements CriterionInterface
             }
         }
 
-        $this->results[] = array_merge($this->results, $childElementsText);
+        $this->results = array_merge($this->results, $childElementsText);
 
         return false;
     }


### PR DESCRIPTION
Failure: https://travis-ci.com/github/ezsystems/ezplatform-form-builder/jobs/524393788

When ChildElementText fails, there's an error:
```
     | SingleLine Custom Form   | Single line input   | Custom single line   |

        Notice: Array to string conversion in vendor/ezsystems/behatbundle/src/lib/Browser/Element/Criterion/ChildElementTextCriterion.php line 58

      Screenshot has been taken. Open image at https://res.cloudinary.com/ezplatformtravis/image/upload/v1626268366/screenshots/60eee2ce4a74d935515446-vendor_ezsystems_ezplatform-form-builder_features_formfieldconfiguration_feature_35_txmj6k.png
```

The result from array_merge should not be appended to the results variable but replace it.

With this change the error message is correct:
```
        Could not find element wih text: 'Single line inputasdasd' among children of given elements. Found names: Single line input instead. Parent css locator 'workspaceField': '.c-form-field'. Child css locator 'workspaceFieldLabel': '.c-form-field__label' (Ibexa\Behat\Browser\Exception\ElementNotFoundException)
```