### PR TITLE
[Regression] Enabled more tests for Ibexa DXP

### DIFF
--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -37,6 +37,7 @@ regression:
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
                 - EzSystems\Behat\API\Context\UserContext

--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -21,22 +21,24 @@ regression:
                 - EzSystems\Behat\Core\Context\FileContext
         commerce:
             paths:
-              - '%paths.base%/vendor/ezsystems/date-based-publisher/features'
-              - '%paths.base%/vendor/ezsystems/ezcommerce-admin-ui/features/standard'
-              - '%paths.base%/vendor/ezsystems/ezcommerce-shop/features'
-              - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/personas'
-              - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
-              - '%paths.base%/vendor/ezsystems/ezplatform-form-builder/features'
-              - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
-              - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
-              - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage'
-              - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas'
+                - '%paths.base%/vendor/ezsystems/date-based-publisher/features'
+                - '%paths.base%/vendor/ezsystems/ezcommerce-admin-ui/features/standard'
+                - '%paths.base%/vendor/ezsystems/ezcommerce-shop/features'
+                - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/personas'
+                - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
+                - '%paths.base%/vendor/ezsystems/ezplatform-form-builder/features'
+                - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage'
+                - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas'
+                - '%paths.base%/vendor/ezsystems/ezplatform-page-fieldtype/features/eventSource'
+                - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
+                - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
                 tags: "~@broken && @IbexaCommerce"
             contexts: 
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
                 - EzSystems\Behat\API\Context\UserContext
@@ -63,6 +65,8 @@ regression:
                 - Ibexa\Behat\Browser\Context\DebuggingContext
                 - Ibexa\Commerce\ShopTools\Behat\Context\FrontContext
                 - Ibexa\Commerce\ShopTools\Behat\Context\UserRegistrationContext
+                - Ibexa\FieldTypePage\Tests\Behat\Context\BlockHideEventsSourceContext
+                - Ibexa\FieldTypePage\Tests\Behat\Context\BlockRevealEventsSourceContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormAdministrationContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormBuilderContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormFieldConfigurationContext
@@ -72,4 +76,3 @@ regression:
                 - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext
-                - EzSystems\Behat\API\Context\RoleContext

--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -27,9 +27,10 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/personas'
               - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
               - '%paths.base%/vendor/ezsystems/ezplatform-form-builder/features'
+              - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
-            #   - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage' As above
-            #   - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas' Uncomment after https://issues.ibexa.co/browse/IBX-601
+              - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage'
+              - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas'
             filters:
                 tags: "~@broken && @IbexaCommerce"
             contexts: 
@@ -61,12 +62,14 @@ regression:
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
                 - Ibexa\Commerce\ShopTools\Behat\Context\FrontContext
+                - Ibexa\Commerce\ShopTools\Behat\Context\UserRegistrationContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormAdministrationContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormBuilderContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormFieldConfigurationContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormFrontContext
                 - Ibexa\PageBuilder\Tests\Behat\Context\PageBuilderContext
                 - Ibexa\Scheduler\Behat\BrowserContext\DateBasedPublisherContext
+                - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext
                 - EzSystems\Behat\API\Context\RoleContext

--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -63,6 +63,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
+                - Ibexa\Commerce\ShopTools\Behat\Context\CheckoutContext
                 - Ibexa\Commerce\ShopTools\Behat\Context\FrontContext
                 - Ibexa\Commerce\ShopTools\Behat\Context\UserRegistrationContext
                 - Ibexa\FieldTypePage\Tests\Behat\Context\BlockHideEventsSourceContext

--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -37,7 +37,6 @@ regression:
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
-                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
                 - EzSystems\Behat\API\Context\UserContext

--- a/behat_ibexa_content.yaml
+++ b/behat_ibexa_content.yaml
@@ -24,6 +24,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/date-based-publisher/features'
               - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/personas'
               - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
+              - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
                 tags: "~@broken && @IbexaContent"
@@ -53,6 +54,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
+                - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Scheduler\Behat\BrowserContext\DateBasedPublisherContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -31,6 +31,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-form-builder/features'
               - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage'
               - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas'
+              - '%paths.base%/vendor/ezsystems/ezplatform-page-fieldtype/features/eventSource'
               - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
@@ -39,6 +40,7 @@ regression:
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
                 - Ibexa\AdminUi\Behat\BrowserContext\AdminUpdateContext
@@ -62,6 +64,8 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
+                - Ibexa\FieldTypePage\Tests\Behat\Context\BlockHideEventsSourceContext
+                - Ibexa\FieldTypePage\Tests\Behat\Context\BlockRevealEventsSourceContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormAdministrationContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormBuilderContext
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormFieldConfigurationContext
@@ -71,4 +75,3 @@ regression:
                 - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext
-                - EzSystems\Behat\API\Context\RoleContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -31,6 +31,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-form-builder/features'
               - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/DynamicLandingPage'
               - '%paths.base%/vendor/ezsystems/ezplatform-page-builder/features/personas'
+              - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
                 tags: "~@broken && @IbexaExperience"
@@ -67,6 +68,7 @@ regression:
                 - Ibexa\FormBuilder\Behat\BrowserContext\FormFrontContext
                 - Ibexa\PageBuilder\Tests\Behat\Context\PageBuilderContext
                 - Ibexa\Scheduler\Behat\BrowserContext\DateBasedPublisherContext
+                - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext
                 - EzSystems\Behat\API\Context\RoleContext

--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -29,7 +29,9 @@ Feature: Editor that has access only to a Subtree of Content Structure
     And I add policy "content" "read" to "BasicRole" with limitations
       | limitationType      | limitationValue                                       |
       | Location            | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test    |
-      | Location            | Users/SubtreeEditorsGroup/SubtreeEditor SubtreeEditor |
+    And I add policy "content" "read" to "BasicRole" with limitations
+      | limitationType      | limitationValue                                        |
+      | Location            | Users/SubtreeEditorsGroup/SubtreeEditor Subtree Editor |
     And I create a role "SubtreeEditorsRole" with policies
       | module      | function           |
       | content     | read               |

--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -29,6 +29,9 @@ Feature: Editor that has access only to a Subtree of Content Structure
     And I add policy "content" "read" to "BasicRole" with limitations
       | limitationType      | limitationValue                                    |
       | Location            | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test |
+    And I add policy "content" "read" to "BasicRole" with limitations
+      | limitationType      | limitationValue  |
+      | Owner               | self             |
     And I create a role "SubtreeEditorsRole" with policies
       | module      | function           |
       | content     | read               |

--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -27,11 +27,9 @@ Feature: Editor that has access only to a Subtree of Content Structure
       | site        | view       |
     And I create a user "ThisUserIsAReviewer" with last name "Test" in group "SubtreeEditorsGroup"
     And I add policy "content" "read" to "BasicRole" with limitations
-      | limitationType      | limitationValue                                    |
-      | Location            | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test |
-    And I add policy "content" "read" to "BasicRole" with limitations
-      | limitationType      | limitationValue  |
-      | Owner               | self             |
+      | limitationType      | limitationValue                                       |
+      | Location            | Users/SubtreeEditorsGroup/ThisUserIsAReviewer Test    |
+      | Location            | Users/SubtreeEditorsGroup/SubtreeEditor SubtreeEditor |
     And I create a role "SubtreeEditorsRole" with policies
       | module      | function           |
       | content     | read               |

--- a/src/lib/Browser/Element/Criterion/LogicalOrCriterion.php
+++ b/src/lib/Browser/Element/Criterion/LogicalOrCriterion.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Element\Criterion;
+
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
+
+class LogicalOrCriterion implements CriterionInterface
+{
+    /** @var \Ibexa\Behat\Browser\Element\Criterion\CriterionInterface[] */
+    private $criterions;
+
+    /** @var string[] */
+    private $results;
+
+    public function __construct(array $criterions = [])
+    {
+        $this->criterions = $criterions;
+    }
+
+    public function addCriterion(CriterionInterface $criterion): void
+    {
+        $this->criterions[] = $criterion;
+    }
+
+    public function matches(ElementInterface $element): bool
+    {
+        foreach ($this->criterions as $criterion) {
+            if ($criterion->matches($element)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getErrorMessage(LocatorInterface $locator): string
+    {
+        $errorMessage = 'LogicalOr criterion failed. Condition error messages:' . PHP_EOL;
+
+        foreach ($this->criterions as $criterion) {
+            $errorMessage .= $criterion->getErrorMessage($locator) . PHP_EOL;
+        }
+
+        return $errorMessage;
+    }
+}

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -27,10 +27,11 @@ class LoginPage extends Page
         $this->getHTMLPage()->find($this->getLocator('username'))->setValue($username);
         $this->getHTMLPage()->find($this->getLocator('password'))->setValue($password);
         $this->getHTMLPage()->findAll($this->getLocator('button'))
-            ->getByCriterion(new LogicalOrCriterion([
+            ->filterBy(new LogicalOrCriterion([
                 new ElementTextCriterion('Login'),
                 new ElementTextCriterion('Sign in'),
             ]))
+            ->single()
             ->click();
 
         Assert::assertNotEquals('/login', $this->getSession()->getCurrentUrl());

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Behat\Browser\Page;
 
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -24,7 +25,7 @@ class LoginPage extends Page
     {
         $this->getHTMLPage()->find($this->getLocator('username'))->setValue($username);
         $this->getHTMLPage()->find($this->getLocator('password'))->setValue($password);
-        $this->getHTMLPage()->find($this->getLocator('button'))->click();
+        $this->getHTMLPage()->findAll($this->getLocator('button'))->getByCriterion(new ElementTextCriterion('Login'))->click();
 
         Assert::assertNotEquals('/login', $this->getSession()->getCurrentUrl());
     }

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\Behat\Browser\Page;
 
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
-use Ibexa\Behat\Browser\Locator\CSSLocator;
+use Ibexa\Behat\Browser\Element\Criterion\LogicalOrCriterion;
+use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
 use PHPUnit\Framework\Assert;
 
 class LoginPage extends Page
@@ -25,7 +26,12 @@ class LoginPage extends Page
     {
         $this->getHTMLPage()->find($this->getLocator('username'))->setValue($username);
         $this->getHTMLPage()->find($this->getLocator('password'))->setValue($password);
-        $this->getHTMLPage()->findAll($this->getLocator('button'))->getByCriterion(new ElementTextCriterion('Login'))->click();
+        $this->getHTMLPage()->findAll($this->getLocator('button'))
+            ->getByCriterion(new LogicalOrCriterion([
+                new ElementTextCriterion('Login'),
+                new ElementTextCriterion('Sign in'),
+            ]))
+            ->click();
 
         Assert::assertNotEquals('/login', $this->getSession()->getCurrentUrl());
     }
@@ -48,9 +54,9 @@ class LoginPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new CSSLocator('username', '#username'),
-            new CSSLocator('password', '#password'),
-            new CSSLocator('button', 'button[type=submit]'),
+            new VisibleCSSLocator('username', '#username'),
+            new VisibleCSSLocator('password', '#password'),
+            new VisibleCSSLocator('button', 'button[type=submit]'),
         ];
     }
 }

--- a/src/lib/Browser/Page/LoginPage.php
+++ b/src/lib/Browser/Page/LoginPage.php
@@ -10,7 +10,7 @@ namespace Ibexa\Behat\Browser\Page;
 
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\Criterion\LogicalOrCriterion;
-use Ibexa\Behat\Browser\Locator\VisibleCSSLocator;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
 class LoginPage extends Page
@@ -54,9 +54,9 @@ class LoginPage extends Page
     protected function specifyLocators(): array
     {
         return [
-            new VisibleCSSLocator('username', '#username'),
-            new VisibleCSSLocator('password', '#password'),
-            new VisibleCSSLocator('button', 'button[type=submit]'),
+            new CSSLocator('username', '#username'),
+            new CSSLocator('password', '#password'),
+            new CSSLocator('button', 'button[type=submit]'),
         ];
     }
 }

--- a/tests/Browser/Element/Criterion/LogicalOrCriterionTest.php
+++ b/tests/Browser/Element/Criterion/LogicalOrCriterionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Criterion;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
+use Ibexa\Behat\Browser\Element\Criterion\LogicalOrCriterion;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use PHPUnit\Framework\Assert;
+
+class LogicalOrCriterionTest extends BaseTestCase
+{
+    public function testMatchesWhenSingleCriterionMatches(): void
+    {
+        $criterions = [
+            new ElementTextCriterion('Test1'),
+            new ElementTextCriterion('Test2'),
+        ];
+        $matchingElement = $this->createElement('Test2');
+
+        $testedCriterion = new LogicalOrCriterion($criterions);
+
+        Assert::assertTrue($testedCriterion->matches($matchingElement));
+    }
+
+    public function testNoMatchWhenNoCriterionMatches(): void
+    {
+        $testedCriterion = new LogicalOrCriterion();
+        $testedCriterion->addCriterion(new ElementTextCriterion('Test1'));
+        $testedCriterion->addCriterion(new ElementTextCriterion('Test2'));
+
+        $nonmatchingElement = $this->createElement('Test3');
+
+        Assert::assertFalse($testedCriterion->matches($nonmatchingElement));
+        Assert::assertEquals("LogicalOr criterion failed. Condition error messages:
+Could not find element named: 'Test1'. Found names: Test3 instead. CSS locator 'id': 'selector'.
+Could not find element named: 'Test2'. Found names: Test3 instead. CSS locator 'id': 'selector'.
+",
+            $testedCriterion->getErrorMessage(new CSSLocator('id', 'selector'))
+        );
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-753

~~Requires https://github.com/ezsystems/BehatBundle/pull/194 to be merged first and then will be rebased to 8.3 branch.~~

1) Added tests from ezplatform-user and ezplatform-page-fieldtype to regression suites
2) On Commerce the Subtree editor tests are failing, because the design requires user to have content/read permissions to itself.

![obraz](https://user-images.githubusercontent.com/10993858/126621006-9efe9a59-3312-45c9-b3ec-f5954dfe0221.png)

Location ID 139 is the Subtree Editor user himself.

I've decided to add it, as it's the quickest way to solve this problem and IMHO it does not change the Subtree Editor scenarios a lot (they still test the things they are supposed to).

3) The current Login page is not able to login on Commerce frontend, because the Login button selector is too broad. 

I haven't found any way to narrow it down (the frontend login page design on OSS is very minimalistic and it's not possible to use meaningful selectors). I didn't want to introduce a separate Login Page for Commerce (seemed like an overkill), so I've introduced a LogicalOr criterion. It uses the Composite pattern and allows to combine multiple Criterions into one - in this case it's used to find an Element which Text is equal either to `Login` or `Sign in`.

Admin panel uses `Sign in`:
<img width="1680" alt="Zrzut ekranu 2021-07-22 o 11 58 53" src="https://user-images.githubusercontent.com/10993858/126621743-68b0d894-3888-4ddf-923a-8b1b6b88ad1a.png">
But `Login` is used in frontend login pages:
<img width="1680" alt="Zrzut ekranu 2021-07-22 o 11 59 02" src="https://user-images.githubusercontent.com/10993858/126621759-bf69030e-1640-4de3-9023-424cc4c89ee6.png">
  



