### PR TITLE
Change find behaviour

### DIFF
--- a/src/lib/Browser/Element/BaseElement.php
+++ b/src/lib/Browser/Element/BaseElement.php
@@ -74,14 +74,17 @@ class BaseElement implements BaseElementInterface
     {
         return $this->waitUntil(
             function () use ($locator) {
-                $minkFoundElement = $this->decoratedElement->find($locator->getType(), $locator->getSelector());
+                $minkFoundElements = $this->decoratedElement->findAll($locator->getType(), $locator->getSelector());
 
-                $foundElement = new Element($locator, $minkFoundElement);
-                if (!$locator->elementMeetsCriteria($foundElement)) {
-                    return false;
+                foreach ($minkFoundElements as $minkElements) {
+                    $wrappedElement = new Element($locator, $minkElements);
+
+                    if ($locator->elementMeetsCriteria($wrappedElement)) {
+                        return $wrappedElement;
+                    }
                 }
 
-                return $foundElement;
+                return false;
             },
             sprintf(
                 "%s selector '%s': '%s' not found in %d seconds.",

--- a/tests/Browser/Element/BaseTestCase.php
+++ b/tests/Browser/Element/BaseTestCase.php
@@ -17,13 +17,13 @@ use PHPUnit\Framework\TestCase;
 
 class BaseTestCase extends TestCase
 {
-    protected function createValidMinkNodeElement(string $elementText): NodeElement
+    protected function createValidMinkNodeElement(string $elementText, bool $isVisible = true): NodeElement
     {
         $elementStub = $this->createStub(NodeElement::class);
 
         $elementStub->method('isValid')->willReturn(true);
         $elementStub->method('getText')->willReturn($elementText);
-        $elementStub->method('isVisible')->willReturn(true);
+        $elementStub->method('isVisible')->willReturn($isVisible);
 
         return $elementStub;
     }


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-264

~~Requires: https://github.com/ezsystems/BehatBundle/pull/194 - will need to be rebased after it's merged and target branch will be changed to 8.3~~

This PR changes how the `find` method works.

You can specify additional conditions using Locators - for example you can use `VisibleCSSLocator` to add a condition that an element must be visible to be found.

Given a simple site with 2 buttons, `InvisibleButton` and `VisibleButton` (`InvisibleButton` is higher in HTML hierarchy).

When you search for a button using:
`$this->getHTMLPage()->find(new VisibleCSSLocator('myButton', 'button')`

Current behaviour:
1) Mink find the first button in the HTML page (the `InvisibleButton` button).
2) Then we check if this element matches the Locator criteria (in our case: it needs to be visible)
3) The button is not visible - the condition is not met

Result:
`Timeout exception` with message:
`CSS selector 'myButton': 'button' not found in 1 seconds.`

New behaviour:
1) Mink finds both elements matching our Locator (`InvisibleButton` and `VisibleButton`)
2) For each button we check if the additional condition is met and return it if true

Result:
`VisibleButton` is returned from the `find` method.

I think that this behaviour is more intuitive and results in better DX.
