### PR TITLE
Added missing Contexts to Experience and Content regression suites

### DIFF
--- a/behat_ibexa_content.yaml
+++ b/behat_ibexa_content.yaml
@@ -29,10 +29,13 @@ regression:
             filters:
                 tags: "~@broken && @IbexaContent"
             contexts: 
+                - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
+                - EzSystems\Behat\API\Context\UserContext
                 - Ibexa\AdminUi\Behat\BrowserContext\AdminUpdateContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentPreviewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext
@@ -54,8 +57,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\UserPreferencesContext
                 - Ibexa\Behat\Browser\Context\AuthenticationContext
                 - Ibexa\Behat\Browser\Context\DebuggingContext
-                - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Scheduler\Behat\BrowserContext\DateBasedPublisherContext
+                - Ibexa\User\Tests\Behat\Context\UserSetupContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowAdminContext
                 - Ibexa\Workflow\Tests\Behat\Context\WorkflowContext
-                - EzSystems\Behat\API\Context\RoleContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -43,6 +43,7 @@ regression:
                 - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\TrashContext
+                - EzSystems\Behat\API\Context\UserContext
                 - Ibexa\AdminUi\Behat\BrowserContext\AdminUpdateContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentPreviewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentTypeContext


### PR DESCRIPTION
Follow-up to https://github.com/ezsystems/BehatBundle/pull/193 - I've added tests from ezplatform-user, but not all Context classes are present in regression suites to run them.

Failures:
https://app.travis-ci.com/github/ezsystems/ezplatform-workflow/jobs/527508654

Content suite:
```
--- Use --snippets-for CLI option to generate snippets for following content suite steps:
    Given I create a user "UnsupportedPasswordUser" with last name "User" in group "Anonymous Users"
    Then the url should match "/site/user/forgot-password/migration"
    And I should see "Your password has expired"
```

https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/527508678
Experience suite:
```
--- Use --snippets-for CLI option to generate snippets for following experience suite steps:

    Given I create a user "UnsupportedPasswordUser" with last name "User" in group "Anonymous Users"
```

The missing steps are defined in [UserContext](https://github.com/ezsystems/BehatBundle/blob/master/src/lib/API/Context/UserContext.php#L40) and MinkContext ([1](https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/Context/MinkContext.php#L283-L293), [2](https://github.com/Behat/MinkExtension/blob/master/src/Behat/MinkExtension/Context/MinkContext.php#L246-L257))

The Contexts lists are also sorted so it's easier to spot duplicates.