### PR TITLE
IBX-650: Added ElementAttributeCriterion

### DIFF
--- a/src/lib/Browser/Element/Criterion/ElementAttributeCriterion.php
+++ b/src/lib/Browser/Element/Criterion/ElementAttributeCriterion.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Element\Criterion;
+
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
+
+class ElementAttributeCriterion implements CriterionInterface
+{
+    /** @var string */
+    private $expectedAttributeValue;
+
+    /** @var array */
+    private $results;
+
+    /** @var string */
+    private $attribute;
+
+    public function __construct(string $attribute, string $expectedAttributeValue)
+    {
+        $this->attribute = $attribute;
+        $this->expectedAttributeValue = $expectedAttributeValue;
+        $this->results = [];
+    }
+
+    public function matches(ElementInterface $element): bool
+    {
+        $actualValue = $element->getAttribute($this->attribute);
+        $this->results[] = $actualValue;
+
+        return $actualValue === $this->expectedAttributeValue;
+    }
+
+    public function getErrorMessage(LocatorInterface $locator): string
+    {
+        return
+            sprintf(
+                "Could not find element with attribute '%s' matching value '%s'. Found values: %s instead. %s locator '%s': '%s'.",
+                $this->attribute,
+                $this->expectedAttributeValue,
+                implode(',', $this->results),
+                $locator->getType(),
+                $locator->getIdentifier(),
+                $locator->getSelector()
+            );
+    }
+}

--- a/src/lib/Browser/Element/Element.php
+++ b/src/lib/Browser/Element/Element.php
@@ -76,7 +76,7 @@ final class Element extends BaseElement implements ElementInterface
 
     public function getAttribute(string $attribute): string
     {
-        return $this->decoratedElement->getAttribute($attribute);
+        return $this->decoratedElement->getAttribute($attribute) ?? '';
     }
 
     public function hasClass(string $class): bool

--- a/tests/Browser/Element/Criterion/ElementAttributeCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ElementAttributeCriterionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Criterion;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Element\Criterion\ElementAttributeCriterion;
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use PHPUnit\Framework\Assert;
+
+class ElementAttributeCriterionTest extends BaseTestCase
+{
+    /**
+     * @dataProvider dataProviderTestMatches
+     */
+    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    {
+        $criterion = new ElementAttributeCriterion('expectedAttribute', 'expectedValue');
+
+        Assert::assertEquals($shouldMatch, $criterion->matches($element));
+    }
+
+    public function dataProviderTestMatches(): array
+    {
+        return [
+            [$this->createElementWithAttribute('expectedAttribute', ''), false],
+            [$this->createElementWithAttribute('expectedAttribute', 'notexpectedValue'), false],
+            [$this->createElementWithAttribute('expectedAttribute', 'expectedValue'), true],
+        ];
+    }
+
+    public function testGetErrorMessage(): void
+    {
+        $criterion = new ElementAttributeCriterion('expectedAttribute', 'expectedValue');
+        $nonMatchingElement = $this->createElementWithAttribute('expectedAttribute', 'notexpectedValue');
+        $criterion->matches($nonMatchingElement);
+
+        Assert::assertEquals(
+            "Could not find element with attribute 'expectedAttribute' matching value 'expectedValue'. Found values: notexpectedValue instead. css locator 'id': 'selector'.",
+            $criterion->getErrorMessage(new CSSLocator('id', 'selector'))
+        );
+    }
+
+    private function createElementWithAttribute($attribute, $value): ElementInterface
+    {
+        $element = $this->createStub(ElementInterface::class);
+        $element->method('getAttribute')->with($attribute)->willReturn($value);
+
+        return $element;
+    }
+}


### PR DESCRIPTION
Added as part of https://issues.ibexa.co/browse/IBX-650, used in ezsystems/ezplatform-admin-ui#1808

Can be used to get an Element from a Collection based on value of a given attribute. I need it for master, but it should be useful for 8.3 as well, hence the backport.

You can see that CI passes for master: https://github.com/ezsystems/BehatBundle/pull/197