### PR TITLE
Added ElementsCountGreaterThanCondition

### DIFF
--- a/src/lib/Browser/Element/Condition/ElementsCountGreaterThanCondition.php
+++ b/src/lib/Browser/Element/Condition/ElementsCountGreaterThanCondition.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Element\Condition;
+
+use Ibexa\Behat\Browser\Element\BaseElementInterface;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
+
+class ElementsCountGreaterThanCondition implements ConditionInterface
+{
+    /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface */
+    private $elementsLocator;
+
+    /** @var \Ibexa\Behat\Browser\Element\BaseElementInterface */
+    private $searchedNode;
+
+    /** @var int */
+    private $expectedElementsCount;
+
+    /** @var int */
+    private $actualNumberOfItemsFound;
+
+    public function __construct(BaseElementInterface $searchedNode, LocatorInterface $elementsLocator, int $expectedElementsCount)
+    {
+        $this->elementsLocator = $elementsLocator;
+        $this->searchedNode = $searchedNode;
+        $this->expectedElementsCount = $expectedElementsCount;
+    }
+
+    public function isMet(): bool
+    {
+        $currentTimeout = $this->searchedNode->getTimeout();
+        $this->searchedNode->setTimeout(0);
+        $actualCount = $this->searchedNode->findAll($this->elementsLocator)->count();
+        $this->searchedNode->setTimeout($currentTimeout);
+        $this->actualNumberOfItemsFound = $actualCount;
+
+        return $actualCount > $this->expectedElementsCount;
+    }
+
+    public function getErrorMessage(BaseElementInterface $invokingElement): string
+    {
+        return sprintf(
+            "The found number of items (%d) matching %s locator '%s': '%s' was not greater than expected value (%d). Timeout value: %d seconds.",
+            $this->actualNumberOfItemsFound,
+            strtoupper($this->elementsLocator->getType()),
+            $this->elementsLocator->getIdentifier(),
+            $this->elementsLocator->getSelector(),
+            $this->expectedElementsCount,
+            $invokingElement->getTimeout()
+        );
+    }
+}

--- a/tests/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Condition;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Element\Condition\ElementsCountGreaterThanCondition;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use PHPUnit\Framework\Assert;
+
+class ElementsCountGreaterThanConditionTest extends BaseTestCase
+{
+    public function testExpectedCountPresent(): void
+    {
+        $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
+        $condition = new ElementsCountGreaterThanCondition(
+            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $searchedElementLocator,
+            0
+        );
+
+        Assert::assertTrue($condition->isMet());
+    }
+
+    public function testExpectedCountNotPresent(): void
+    {
+        $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
+        $condition = new ElementsCountGreaterThanCondition(
+            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $searchedElementLocator,
+            1
+        );
+        $invokingElement = $this->createElement('Test');
+        $invokingElement->method('getTimeout')->willReturn(5);
+
+        Assert::assertFalse($condition->isMet());
+        Assert::assertEquals(
+            "The found number of items (1) matching CSS locator 'searched-id': 'searched-test' was not greater than expected value (1). Timeout value: 5 seconds.",
+            $condition->getErrorMessage($invokingElement)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a new Condition that checks whether the actual numbers of Elements is greater than the given one.

Sometimes it's useful to make sure that enough elements were found without specyfing the exact amount (which can vary depending on product edition etc.).

Example usage:
```
$this->getHTMLPage()
     ->setTimeout(5)
     ->waitUntilCondition(
        new ElementsCountGreaterThanCondition($this->getHTMLPage(), $this->getLocator('buttons'), 5)
    )
    ->findAll(...) // continue only after at least 6 buttons have been found
```

It's named after the PHPUnit Assertion: https://phpunit.readthedocs.io/en/9.5/assertions.html#assertgreaterthan and works in the same way.