### PR TITLE
Fixed behaviour of first and last on empty collection

### DIFF
--- a/src/lib/Browser/Element/ElementCollection.php
+++ b/src/lib/Browser/Element/ElementCollection.php
@@ -72,6 +72,15 @@ class ElementCollection implements \Countable, \IteratorAggregate
         foreach ($this->elements as $element) {
             return $element;
         }
+
+        throw new ElementNotFoundException(
+            sprintf(
+                "Collection created with %s locator '%s': '%s' is empty.",
+                strtoupper($this->locator->getType()),
+                $this->locator->getIdentifier(),
+                $this->locator->getSelector()
+            )
+        );
     }
 
     public function last(): ElementInterface
@@ -80,7 +89,20 @@ class ElementCollection implements \Countable, \IteratorAggregate
             $this->elements = iterator_to_array($this->elements);
         }
 
-        return end($this->elements);
+        $lastElement = end($this->elements);
+
+        if (!$lastElement) {
+            throw new ElementNotFoundException(
+                sprintf(
+                    "Collection created with %s locator '%s': '%s' is empty.",
+                    strtoupper($this->locator->getType()),
+                    $this->locator->getIdentifier(),
+                    $this->locator->getSelector()
+                )
+            );
+        }
+
+        return $lastElement;
     }
 
     /**

--- a/tests/Browser/Element/ElementCollectionTest.php
+++ b/tests/Browser/Element/ElementCollectionTest.php
@@ -12,6 +12,7 @@ use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
 use Ibexa\Behat\Browser\Element\ElementCollection;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
+use Ibexa\Behat\Browser\Exception\ElementNotFoundException;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -33,9 +34,23 @@ class ElementCollectionTest extends BaseTestCase
         Assert::assertEquals('Element1', $this->collection->first()->getText());
     }
 
+    public function testFirstThrowsExceptionWhenEmpty(): void
+    {
+        $emptyCollection = $this->createCollection(new CSSLocator('identifier', 'selector'));
+        $this->expectException(ElementNotFoundException::class);
+        $emptyCollection->first();
+    }
+
     public function testLastReturnsLastElement(): void
     {
         Assert::assertEquals('Element3', $this->collection->last()->getText());
+    }
+
+    public function testLastThrowsExceptionWhenEmpty(): void
+    {
+        $emptyCollection = $this->createCollection(new CSSLocator('identifier', 'selector'));
+        $this->expectException(ElementNotFoundException::class);
+        $emptyCollection->last();
     }
 
     public function testCount(): void


### PR DESCRIPTION
When a collection is empty (`findAll` did not return any elements) the current results of calling `first` and `last` methods are:
- first: `Return value of Ibexa\Behat\Browser\Element\ElementCollection::first() must implement interface Ibexa\Behat\Browser\Element\ElementInterface, none returned`
- last: `Return value of Ibexa\Behat\Browser\Element\ElementCollection::last() must implement interface Ibexa\Behat\Browser\Element\ElementInterface, bool returned`

This PR fixes it - when the collection is empty an exception will be thrown instead.