### PR TITLE
Added ElementTextFragmentCriterion

### DIFF
--- a/src/lib/Browser/Element/Criterion/ElementTextFragmentCriterion.php
+++ b/src/lib/Browser/Element/Criterion/ElementTextFragmentCriterion.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Element\Criterion;
+
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
+
+class ElementTextFragmentCriterion implements CriterionInterface
+{
+    /**
+     * @var string
+     */
+    private $expectedElementTextFragment;
+
+    /** @var array */
+    private $results;
+
+    public function __construct(string $expectedElementTextFragment)
+    {
+        $this->expectedElementTextFragment = $expectedElementTextFragment;
+        $this->results = [];
+    }
+
+    public function matches(ElementInterface $element): bool
+    {
+        $actualValue = $element->getText();
+        $this->results[] = $actualValue;
+
+        return false !== strpos($actualValue, $this->expectedElementTextFragment);
+    }
+
+    public function getErrorMessage(LocatorInterface $locator): string
+    {
+        return
+            sprintf(
+                "Could not find element with text containing: '%s'. Found texts: %s instead. %s locator '%s': '%s'.",
+                $this->expectedElementTextFragment,
+                implode(',', $this->results),
+                strtoupper($locator->getType()),
+                $locator->getIdentifier(),
+                $locator->getSelector()
+            );
+    }
+}

--- a/tests/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Criterion;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Element\Criterion\ElementTextFragmentCriterion;
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use PHPUnit\Framework\Assert;
+
+class ElementTextFragmentCriterionTest extends BaseTestCase
+{
+    /**
+     * @dataProvider dataProviderTestMatches
+     */
+    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    {
+        $criterion = new ElementTextFragmentCriterion('text');
+
+        Assert::assertEquals($shouldMatch, $criterion->matches($element));
+    }
+
+    public function dataProviderTestMatches(): array
+    {
+        return [
+            [$this->createElement('text'), true],
+            [$this->createElement('thisIsALongertext'), true],
+            [$this->createElement('thisStringDoesNotContainText'), false],
+        ];
+    }
+
+    public function testGetErrorMessage(): void
+    {
+        $criterion = new ElementTextFragmentCriterion('expectedText');
+        $nonMatchingElement = $this->createElement('actualText');
+        $criterion->matches($nonMatchingElement);
+
+        Assert::assertEquals(
+            "Could not find element with text containing: 'expectedText'. Found texts: actualText instead. CSS locator 'id': 'selector'.",
+            $criterion->getErrorMessage(new CSSLocator('id', 'selector'))
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a small feature that allows you to get an element based on a fragment of its text.

Real life example - headers in some tables:
<img width="746" alt="Zrzut ekranu 2021-09-14 o 13 34 25" src="https://user-images.githubusercontent.com/10993858/133250412-fa5794c6-5ee5-42ba-90cd-1a9c62b47319.png">

Let's say you want to get the header for Stage "Draft" you can't use `ElementTextCriterion`, because the number of items in that stage varies.

Currently you'd need to do something like:
```php
$searchedHeader = null;
$headers = $this->getHTMLPage()->findAll($headerLocator);
foreach ($headers as $header) {
  if (false !== strpos($headers->getText(), 'Draft') {
    $searchedHeader = $header;
  }
}
$searchedHeader->click(); // or something else
```

With the new criterion you can do it like this:
```php
$this->getHTMLPage()
   ->findAll($headerLocator)
   ->getByCriterion(new ElementTextFragmentCriterion('Draft'))
   ->click();
```
ElementTextFragmentCriterion will match when the text of an Element contains given string.

