### PR TITLE
[Behat][Redesign] Fix for drag-mock library

### DIFF
--- a/src/bundle/Resources/encore/ez.config.manager.js
+++ b/src/bundle/Resources/encore/ez.config.manager.js
@@ -21,6 +21,17 @@ module.exports = (eZConfig, eZConfigManager) => {
         ]
     });
 
+    if (eZConfig.entry['ezplatform-admin-ui-content-type-edit-js']) {
+        const dragMockScriptPath = '../public/js/scripts/drag-mock.js';
+        eZConfigManager.add({
+            eZConfig,
+            entryName: 'ezplatform-admin-ui-content-type-edit-js',
+            newItems: [
+                path.resolve(__dirname, dragMockScriptPath),
+            ],
+        });
+    }
+
     if (eZConfig.entry['ezplatform-page-builder-edit-js']) {
         const dragMockScriptPath = '../public/js/scripts/drag-mock.js';
         eZConfigManager.add({


### PR DESCRIPTION
PR is connected to: https://github.com/ezsystems/ezplatform-admin-ui/pull/1835

This PR adds drag-mock library to _ezplatform-admin-ui-content-type-edit-js_ to avoid : ` RuntimeException: drag-mock library has to be added to the page in order to use this method. ` errors.