### PR TITLE
Change multirepository setup

### DIFF
--- a/bin/.travis/prepare_multirepository_setup.sh
+++ b/bin/.travis/prepare_multirepository_setup.sh
@@ -5,6 +5,9 @@ cd "$HOME/build/project";
 # Drop database used by default connection
 docker-compose exec --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
 
+# Clear SPI cache
+docker-compose exec --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+
 # Run setup
 docker-compose exec --user www-data app sh -c "vendor/bin/ezbehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml"
 docker-compose exec --user www-data app sh -c "composer run post-install-cmd"

--- a/features/setup/multirepository/multirepository.feature
+++ b/features/setup/multirepository/multirepository.feature
@@ -7,26 +7,8 @@ Feature: Multirepository setup for testing
         default_connection: default
         connections:
             default:
-                driver: '%database_driver%'
-                charset: '%database_charset%'
-                default_table_options:
-                    charset: '%database_charset%'
-                    collate: '%database_collation%'
                 url: 'mysql://INVALID:INVALID@127.0.0.1/INVALID'
-            site_factory:
-                # configure these for your database server
-                driver: '%database_driver%'
-                charset: '%database_charset%'
-                default_table_options:
-                    charset: '%database_charset%'
-                    collate: '%database_collation%'
-                url: '%env(resolve:DATABASE_URL)%'
             second_connection:
-                driver: '%database_driver%'
-                charset: '%database_charset%'
-                default_table_options:
-                    charset: '%database_charset%'
-                    collate: '%database_collation%'
                 url: '%env(resolve:DATABASE_URL)%'
     """
     And I set configuration to "ezplatform.repositories.new_repository"


### PR DESCRIPTION
## Things done
### SPI cache is cleared between database installs.

This is required, because some installers use Ibexa Migrations which create items in the database using our API. Because the API is used it's not enough to drop the database - there are still some leftovers in the SPI cache which are causing issues. We use `CACHE_POOL` if defined (for example: when redis is defined: https://github.com/ibexa/docker/blob/main/docker/redis.yml#L13), otherwise we fallback to the default value (https://github.com/ibexa/content-skeleton/blob/v3.3.10/.env#L43)

### Connection configuration is simplified
- it's required to have multirepository tests on the Content edition
- The Site Factory connection can be removed, because it's defined in another file in v3.3: https://github.com/ibexa/experience-skeleton/blob/v3.3.10/config/packages/ezplatform_site_factory.yaml#L18-L29
- In the product the connection is defined using the URL property (https://github.com/ibexa/content-skeleton/blob/v3.3.10/config/packages/doctrine.yaml#L3), so it's fine to define it that way in multirepo setup as well. The Doctrine doc mentions both of them (https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#getting-a-connection), adding that URL is simpler

I've tested it on Content, Experience and Commerce in https://github.com/ezsystems/ezplatform-workflow/pull/237 and https://github.com/ezsystems/ezplatform-page-builder/pull/865