### PR TITLE
Added ElementTransitionHasEnded condition

### DIFF
--- a/src/bundle/Resources/encore/ez.config.manager.js
+++ b/src/bundle/Resources/encore/ez.config.manager.js
@@ -1,65 +1,27 @@
 const path = require('path');
 
 module.exports = (eZConfig, eZConfigManager) => {
+    const addEntry = ([entryName, newItems]) => {
+        if (eZConfig.entry[entryName]) {
+            eZConfigManager.add({
+                eZConfig,
+                entryName,
+                newItems,
+            });
+        }
+    };
+    const seleniumDebugStylePath = path.resolve(__dirname, '../public/css/selenium-debug.css');
+    const dragMockScriptPath = path.resolve(__dirname, '../public/js/scripts/drag-mock.js');
+    const transitionListenerScriptPath = path.resolve(__dirname, '../public/js/scripts/transition-listener.js');
+    const scriptsMap = {
+        'ezcommerce-shop-pagelayout-css': [seleniumDebugStylePath],
+        'ezplatform-admin-ui-content-type-edit-js': [dragMockScriptPath],
+        'ezplatform-admin-ui-layout-css': [seleniumDebugStylePath],
+        'ezplatform-admin-ui-layout-js': [transitionListenerScriptPath],
+        'ezplatform-admin-ui-security-base-css': [seleniumDebugStylePath],
+        'ezplatform-form-builder-common-js': [dragMockScriptPath],
+        'ezplatform-page-builder-edit-js': [dragMockScriptPath],
+    };
 
-    const dragMockScriptPath = '../public/js/scripts/drag-mock.js';
-    const seleniumDebugStylePath = '../public/css/selenium-debug.css';
-
-    eZConfigManager.add({
-        eZConfig,
-        entryName: 'ezplatform-admin-ui-layout-css',
-        newItems: [
-            path.resolve(__dirname, seleniumDebugStylePath)
-        ]
-    });
-
-    eZConfigManager.add({
-        eZConfig,
-        entryName: 'ezplatform-admin-ui-security-base-css',
-        newItems: [
-            path.resolve(__dirname, seleniumDebugStylePath)
-        ]
-    });
-
-    if (eZConfig.entry['ezplatform-admin-ui-content-type-edit-js']) {
-        const dragMockScriptPath = '../public/js/scripts/drag-mock.js';
-        eZConfigManager.add({
-            eZConfig,
-            entryName: 'ezplatform-admin-ui-content-type-edit-js',
-            newItems: [
-                path.resolve(__dirname, dragMockScriptPath),
-            ],
-        });
-    }
-
-    if (eZConfig.entry['ezplatform-page-builder-edit-js']) {
-        const dragMockScriptPath = '../public/js/scripts/drag-mock.js';
-        eZConfigManager.add({
-            eZConfig,
-            entryName: 'ezplatform-page-builder-edit-js',
-            newItems: [
-                path.resolve(__dirname, dragMockScriptPath),
-            ],
-        });
-    }
-    
-    if (eZConfig.entry['ezplatform-form-builder-common-js']) {
-        eZConfigManager.add({
-            eZConfig,
-            entryName: 'ezplatform-form-builder-common-js',
-            newItems: [
-                path.resolve(__dirname, dragMockScriptPath),
-            ],
-        });
-    }
-
-    if (eZConfig.entry['ezcommerce-shop-pagelayout-css']) {
-        eZConfigManager.add({
-            eZConfig,
-            entryName: 'ezcommerce-shop-pagelayout-css',
-            newItems: [
-                path.resolve(__dirname, seleniumDebugStylePath)
-            ]
-        });
-    }
+    Object.entries(scriptsMap).forEach(addEntry);
 };

--- a/src/bundle/Resources/public/js/scripts/transition-listener.js
+++ b/src/bundle/Resources/public/js/scripts/transition-listener.js
@@ -1,0 +1,3 @@
+const transitionEndedClass = 'ibexa-selenium-transition-ended';
+document.addEventListener('transitionstart', (event) => event.target.classList.remove(transitionEndedClass));
+document.addEventListener('transitionend', (event) => event.target.classList.add(transitionEndedClass));

--- a/src/lib/Browser/Element/Condition/ElementTransitionHasEndedCondition.php
+++ b/src/lib/Browser/Element/Condition/ElementTransitionHasEndedCondition.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Behat\Browser\Element\Condition;
+
+use Ibexa\Behat\Browser\Element\BaseElementInterface;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
+
+class ElementTransitionHasEndedCondition implements ConditionInterface
+{
+    private const TRANSITION_ENDED_CLASS = 'ibexa-selenium-transition-ended';
+
+    /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface */
+    private $elementLocator;
+
+    /** @var \Ibexa\Behat\Browser\Element\BaseElementInterface */
+    private $searchedNode;
+
+    public function __construct(BaseElementInterface $searchedNode, LocatorInterface $elementLocator)
+    {
+        $this->elementLocator = $elementLocator;
+        $this->searchedNode = $searchedNode;
+    }
+
+    public function isMet(): bool
+    {
+        $currentTimeout = $this->searchedNode->getTimeout();
+        $this->searchedNode->setTimeout(0);
+        $hasTransitionEndedClass = $this->searchedNode->find($this->elementLocator)->hasClass(self::TRANSITION_ENDED_CLASS);
+        $this->searchedNode->setTimeout($currentTimeout);
+
+        return $hasTransitionEndedClass;
+    }
+
+    public function getErrorMessage(BaseElementInterface $invokingElement): string
+    {
+        return sprintf(
+            "Transition has not ended for element with %s locator '%s': '%s'. Timeout value: %d seconds.",
+            strtoupper($this->elementLocator->getType()),
+            $this->elementLocator->getIdentifier(),
+            $this->elementLocator->getSelector(),
+            $invokingElement->getTimeout()
+        );
+    }
+}

--- a/src/lib/Browser/Element/Debug/Highlighting/BaseElement.php
+++ b/src/lib/Browser/Element/Debug/Highlighting/BaseElement.php
@@ -98,17 +98,6 @@ class BaseElement implements BaseElementInterface
         );
     }
 
-    protected function removeClass(ElementInterface $element, string $class): void
-    {
-        $this->session->executeScript(
-            sprintf(
-                "%s.classList.remove('%s')",
-                $this->getElementScript($element),
-                $class
-            )
-        );
-    }
-
     protected function markRead(ElementInterface $element): void
     {
         $this->addClass($element, self::READ_CLASS);

--- a/tests/Browser/Element/BaseTestCase.php
+++ b/tests/Browser/Element/BaseTestCase.php
@@ -36,26 +36,26 @@ class BaseTestCase extends TestCase
         return $element;
     }
 
-    protected function createElementWithChildElement(string $elementText, LocatorInterface $childLocator, string $childElementText): ElementInterface
+    protected function createElementWithChildElement(string $elementText, LocatorInterface $childLocator, ElementInterface $childElement): ElementInterface
     {
         $element = $this->createMock(ElementInterface::class);
         $element->method('getText')->willReturn($elementText);
         $element->method('getTimeout')->willReturn(1);
-        $element->method('find')->willReturnCallback(function () use ($childLocator, $childElementText) {
+        $element->method('find')->willReturnCallback(static function () use ($childLocator, $childElement) {
             /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface $locator */
             $locator = func_get_args()[0];
             if ($locator == $childLocator) {
-                return $this->createElement($childElementText);
+                return $childElement;
             }
 
             throw new TimeoutException();
         });
 
-        $element->method('findAll')->willReturnCallback(function () use ($childLocator, $childElementText) {
+        $element->method('findAll')->willReturnCallback(function () use ($childLocator, $childElement) {
             /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface $locator */
             $locator = func_get_args()[0];
             if ($locator == $childLocator) {
-                return $this->createCollection($childLocator, $childElementText);
+                return $this->createCollection($childLocator, $childElement->getText());
             }
 
             return $this->createCollection($childLocator);

--- a/tests/Browser/Element/Condition/ElementExistsConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementExistsConditionTest.php
@@ -19,7 +19,7 @@ class ElementExistsConditionTest extends BaseTestCase
     {
         $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
         $condition = new ElementExistsCondition(
-            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText')),
             $searchedElementLocator
         );
 
@@ -29,7 +29,7 @@ class ElementExistsConditionTest extends BaseTestCase
     public function testElementDoesNotExist(): void
     {
         $condition = new ElementExistsCondition(
-            $this->createElementWithChildElement('root', new CSSLocator('irrelevant-id', 'irrelevant-child'), 'ChildText'),
+            $this->createElementWithChildElement('root', new CSSLocator('irrelevant-id', 'irrelevant-child'), $this->createElement('ChildText')),
             new CSSLocator('searched-id', 'searched-test')
         );
 

--- a/tests/Browser/Element/Condition/ElementNotExistsConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementNotExistsConditionTest.php
@@ -20,7 +20,9 @@ class ElementNotExistsConditionTest extends BaseTestCase
         $searchedElementLocator = new CSSLocator('not-exist-id', 'not-exist-selector');
         $condition = new ElementNotExistsCondition(
             $this->createElementWithChildElement(
-                'root', new CSSLocator('dummy-id', 'dummy-selector'), 'DummyText',
+                'root',
+                new CSSLocator('dummy-id', 'dummy-selector'),
+                $this->createElement('DummyText')
             ),
             $searchedElementLocator
         );
@@ -32,7 +34,7 @@ class ElementNotExistsConditionTest extends BaseTestCase
     {
         $shouldNotExistLocator = new CSSLocator('should-not-exist-id', 'should-not-exist-selector');
         $condition = new ElementNotExistsCondition(
-            $this->createElementWithChildElement('root', $shouldNotExistLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $shouldNotExistLocator, $this->createElement('ChildText')),
             $shouldNotExistLocator
         );
         $invokingElement = $this->createElement('Test');

--- a/tests/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementTransitionHasEndedConditionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Condition;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Element\Condition\ElementTransitionHasEndedCondition;
+use Ibexa\Behat\Browser\Element\ElementInterface;
+use Ibexa\Behat\Browser\Locator\CSSLocator;
+use PHPUnit\Framework\Assert;
+
+class ElementTransitionHasEndedConditionTest extends BaseTestCase
+{
+    public function testElementConditionHasEnded(): void
+    {
+        $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
+        $childElement = $this->createStub(ElementInterface::class);
+        $childElement->method('getText')->willReturn('ChildText');
+        $childElement->method('hasClass')->will($this->returnValueMap([
+                ['ibexa-selenium-transition-ended', true],
+            ]
+        ));
+
+        $condition = new ElementTransitionHasEndedCondition(
+            $this->createElementWithChildElement('root', $searchedElementLocator, $childElement),
+            $searchedElementLocator
+        );
+
+        Assert::assertTrue($condition->isMet());
+    }
+
+    public function testElementDoesNotHaveExpectedClass(): void
+    {
+        $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
+        $baseElement = $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText'));
+        $condition = new ElementTransitionHasEndedCondition(
+            $baseElement,
+            $searchedElementLocator
+        );
+
+        Assert::assertFalse($condition->isMet());
+        Assert::assertEquals(
+            "Transition has not ended for element with CSS locator 'searched-id': 'searched-test'. Timeout value: 1 seconds.",
+            $condition->getErrorMessage($baseElement)
+        );
+    }
+}

--- a/tests/Browser/Element/Condition/ElementsCountConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementsCountConditionTest.php
@@ -19,7 +19,7 @@ class ElementsCountConditionTest extends BaseTestCase
     {
         $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
         $condition = new ElementsCountCondition(
-            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText')),
             $searchedElementLocator,
             1
         );
@@ -31,7 +31,7 @@ class ElementsCountConditionTest extends BaseTestCase
     {
         $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
         $condition = new ElementsCountCondition(
-            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText')),
             $searchedElementLocator,
             0
         );

--- a/tests/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
+++ b/tests/Browser/Element/Condition/ElementsCountGreaterThanConditionTest.php
@@ -19,7 +19,7 @@ class ElementsCountGreaterThanConditionTest extends BaseTestCase
     {
         $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
         $condition = new ElementsCountGreaterThanCondition(
-            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText')),
             $searchedElementLocator,
             0
         );
@@ -31,7 +31,7 @@ class ElementsCountGreaterThanConditionTest extends BaseTestCase
     {
         $searchedElementLocator = new CSSLocator('searched-id', 'searched-test');
         $condition = new ElementsCountGreaterThanCondition(
-            $this->createElementWithChildElement('root', $searchedElementLocator, 'ChildText'),
+            $this->createElementWithChildElement('root', $searchedElementLocator, $this->createElement('ChildText')),
             $searchedElementLocator,
             1
         );

--- a/tests/Browser/Element/Criterion/ChildElementTextCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ChildElementTextCriterionTest.php
@@ -30,9 +30,9 @@ class ChildElementTextCriterionTest extends BaseTestCase
     public function dataProviderTestMatches(): array
     {
         return [
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), 'expectedChildText'), true],
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), 'notExpectedChildText'), false],
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'invalidSelector'), 'expectedChildText'), false],
+            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), $this->createElement('expectedChildText')), true],
+            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), $this->createElement('notExpectedChildText')), false],
+            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'invalidSelector'), $this->createElement('expectedChildText')), false],
         ];
     }
 
@@ -40,7 +40,7 @@ class ChildElementTextCriterionTest extends BaseTestCase
     {
         $childLocator = new XPathLocator('id', 'child-selector');
         $criterion = new ChildElementTextCriterion($childLocator, 'expectedChildText');
-        $invalidElement = $this->createElementWithChildElement('ignore', $childLocator, 'expectedChildText');
+        $invalidElement = $this->createElementWithChildElement('ignore', $childLocator, $this->createElement('expectedChildText'));
         $criterion->matches($invalidElement);
 
         Assert::assertEquals(
@@ -56,7 +56,7 @@ class ChildElementTextCriterionTest extends BaseTestCase
     {
         $childLocator = new XPathLocator('id', 'child-selector');
         $criterion = new ChildElementTextCriterion($childLocator, 'expectedChildText');
-        $invalidElement = $this->createElementWithChildElement('ignore', $childLocator, 'notExpectedChildText');
+        $invalidElement = $this->createElementWithChildElement('ignore', $childLocator, $this->createElement('notExpectedChildText'));
         $criterion->matches($invalidElement);
 
         Assert::assertEquals(


### PR DESCRIPTION
## Goal:
Add a new condition that allows us to detect in browser tests when a CSS transition has ended. An event listener is added that fires when a transition ends and adds a special class (`ibexa-selenium-transition-ended`) that we can later detect in tests.

https://user-images.githubusercontent.com/10993858/137711537-f74e5ca8-6d38-4956-93d2-8120a34914ad.mp4

## Example usage:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1969/files

## Commits: 
### https://github.com/ezsystems/BehatBundle/pull/220/commits/fe6b4bcd864d0871810db08ff8e1f3d301d13a45 - JavaScript changes

I've added the event listener and reorganised config manager to make it a bit more readable.
### https://github.com/ezsystems/BehatBundle/pull/220/commits/6b2acdb889328a12d3770639109ca67c0a4b684d - PHP code (added the condition)

### https://github.com/ezsystems/BehatBundle/pull/220/commits/009bd1d29d1a44d130b54063366a8aba4ce57c09 - tests (PHP)

This PR is for master, because I want to make sure it solves the issue present there - if it works then I will backport it to 8.3 branch.