### PR TITLE
IBX-1228: Adapted CacheGeneratorInterface namespace

### DIFF
--- a/API/Facade/ContentTypeFacade.php
+++ b/API/Facade/ContentTypeFacade.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use EzSystems\EzPlatformAdminUi\Behat\PageElement\Fields\EzFieldElement;
-use Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 class ContentTypeFacade
@@ -24,7 +24,7 @@ class ContentTypeFacade
     /** @var Symfony\Component\Cache\Adapter\TagAwareAdapterInterface */
     private $cachePool;
 
-    /** @var Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface */
+    /** @var Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface */
     private $cacheIdentifierGenerator;
 
     private const MAX_LOAD_TRIES = 10;


### PR DESCRIPTION
This is a follow-up for https://github.com/ezsystems/ezpublish-kernel/pull/3122 to fix failing tests related to the changed namespace, ref: https://app.travis-ci.com/github/ezsystems/ezpublish-kernel/jobs/544254742#L1165.