### PR TITLE
Mark items for which the transition has started

### DIFF
--- a/src/bundle/Resources/public/js/scripts/transition-listener.js
+++ b/src/bundle/Resources/public/js/scripts/transition-listener.js
@@ -1,3 +1,10 @@
 const transitionEndedClass = 'ibexa-selenium-transition-ended';
-document.addEventListener('transitionstart', (event) => event.target.classList.remove(transitionEndedClass));
-document.addEventListener('transitionend', (event) => event.target.classList.add(transitionEndedClass));
+const transitionStartedClass = 'ibexa-selenium-transition-started';
+document.addEventListener('transitionstart', (event) => {
+    event.target.classList.add(transitionStartedClass)
+    event.target.classList.remove(transitionEndedClass)
+});
+document.addEventListener('transitionend', (event) => {
+    event.target.classList.add(transitionEndedClass)
+    event.target.classList.remove(transitionStartedClass)
+});

--- a/src/lib/Browser/Element/Condition/ElementTransitionHasEndedCondition.php
+++ b/src/lib/Browser/Element/Condition/ElementTransitionHasEndedCondition.php
@@ -15,11 +15,16 @@ class ElementTransitionHasEndedCondition implements ConditionInterface
 {
     private const TRANSITION_ENDED_CLASS = 'ibexa-selenium-transition-ended';
 
+    private const TRANSITION_STARTED_CLASS = 'ibexa-selenium-transition-started';
+
     /** @var \Ibexa\Behat\Browser\Locator\LocatorInterface */
     private $elementLocator;
 
     /** @var \Ibexa\Behat\Browser\Element\BaseElementInterface */
     private $searchedNode;
+
+    /** @var bool */
+    private $hasStartedTransitioning;
 
     public function __construct(BaseElementInterface $searchedNode, LocatorInterface $elementLocator)
     {
@@ -31,6 +36,8 @@ class ElementTransitionHasEndedCondition implements ConditionInterface
     {
         $currentTimeout = $this->searchedNode->getTimeout();
         $this->searchedNode->setTimeout(0);
+
+        $this->hasStartedTransitioning = $this->searchedNode->find($this->elementLocator)->hasClass(self::TRANSITION_STARTED_CLASS);
         $hasTransitionEndedClass = $this->searchedNode->find($this->elementLocator)->hasClass(self::TRANSITION_ENDED_CLASS);
         $this->searchedNode->setTimeout($currentTimeout);
 
@@ -39,12 +46,21 @@ class ElementTransitionHasEndedCondition implements ConditionInterface
 
     public function getErrorMessage(BaseElementInterface $invokingElement): string
     {
-        return sprintf(
-            "Transition has not ended for element with %s locator '%s': '%s'. Timeout value: %d seconds.",
-            strtoupper($this->elementLocator->getType()),
-            $this->elementLocator->getIdentifier(),
-            $this->elementLocator->getSelector(),
-            $invokingElement->getTimeout()
-        );
+        return $this->hasStartedTransitioning ?
+            sprintf(
+                "Transition has not ended for element with %s locator '%s': '%s'. Timeout value: %d seconds.",
+                strtoupper($this->elementLocator->getType()),
+                $this->elementLocator->getIdentifier(),
+                $this->elementLocator->getSelector(),
+                $invokingElement->getTimeout()
+            )
+            :
+            sprintf(
+                "Transition has not started at all for element with %s locator '%s': '%s'. Please make sure the condition is used on the correct element. Timeout value: %d seconds.",
+                strtoupper($this->elementLocator->getType()),
+                $this->elementLocator->getIdentifier(),
+                $this->elementLocator->getSelector(),
+                $invokingElement->getTimeout()
+            );
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/ezsystems/BehatBundle/pull/220 which will allow us to detect if the transition has been started at all.

This makes the Condition easier to use:
1) If the transition has started but did not end in time the error message will be similar to:
```
    And I go to "Content structure" in "Content" tab                      # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iGoToTab()
      Transition has not ended for element with CSS locator 'menuFirstLevel': '.ibexa-main-menu__navbar--first-level'. Timeout value: 3 seconds. (Ibexa\Behat\Browser\Exception\TimeoutException)
```
2) If the transition has not started at all (because the Condition is used on an incorrect element or too early) then the error message will be:
```
    And I go to "Content structure" in "Content" tab                      # Ibexa\AdminUi\Behat\BrowserContext\NavigationContext::iGoToTab()
      Transition has not started at all for element with CSS locator 'menuSelector': '.ibexa-main-menu'. Please make sure the condition is used on the correct element. Timeout value: 3 seconds. (Ibexa\Behat\Browser\Exception\TimeoutException)
```

This should improve our DX, as it's easy to use this condition on a wrong element and then there is nothing in the code that helps detect that.