### PR TITLE
IBX-1228: Adjusted `CacheIdentifierGeneratorInterface` namespace

### DIFF
--- a/src/lib/API/Facade/ContentTypeFacade.php
+++ b/src/lib/API/Facade/ContentTypeFacade.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use EzSystems\Behat\API\ContentData\FieldTypeNameConverter;
-use Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 class ContentTypeFacade
@@ -28,7 +28,7 @@ class ContentTypeFacade
     /** @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface */
     private $cachePool;
 
-    /** @var \Ibexa\Core\Persistence\Cache\Tag\CacheIdentifierGeneratorInterface */
+    /** @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface */
     private $cacheIdentifierGenerator;
 
     public function __construct(


### PR DESCRIPTION
Depends on: https://github.com/ezsystems/ezplatform-kernel/pull/255.