### PR TITLE
Fixed user group searching for system user groups

### DIFF
--- a/src/lib/API/Facade/UserFacade.php
+++ b/src/lib/API/Facade/UserFacade.php
@@ -109,6 +109,28 @@ class UserFacade
         $query = new Query();
         $query->filter = new Criterion\LogicalAnd([
             new Criterion\ContentTypeIdentifier(self::USERGROUP_CONTENT_IDENTIFIER),
+            new Criterion\Field('name', Criterion\Operator::EQ, $userGroupName),
+        ]);
+
+        $result = $this->searchService->findContent($query);
+
+        if (count($result->searchHits) > 0) {
+            $content = $result->searchHits[0]->valueObject;
+
+            return $this->userService->loadUserGroup($content->contentInfo->id);
+        }
+
+        return $this->loadLegacyUserGroupByName($userGroupName);
+    }
+
+    private function loadLegacyUserGroupByName(string $userGroupName): UserGroup
+    {
+        // There are some groups that loadUserGroupByName cannot load (missing data in SQL installer)
+        // We need to use a broader criterion to find them
+
+        $query = new Query();
+        $query->filter = new Criterion\LogicalAnd([
+            new Criterion\ContentTypeIdentifier(self::USERGROUP_CONTENT_IDENTIFIER),
         ]);
 
         $result = $this->searchService->findContent($query);


### PR DESCRIPTION
Issue: currently you can't use a step like this one:
https://github.com/ezsystems/ezplatform-user/blob/master/features/browser/signIn.feature#L6

with groups like "Administrator users" because current code fails to find them.

Error message:
```
Notice: Undefined offset: 0 in vendor/ezsystems/behatbundle/src/lib/API/Facade/UserFacade.php line 137
```

Solution:
We can't rely solely on `Field` criterion, because some system user groups are missing the correct value in `sort_key_string` in SQL installer and LSE fails to find them. This PR adds a fallback method for User Group searching (which will be used when the primary one fails).