### PR TITLE
Removed whitespace from tag filters

### DIFF
--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -33,7 +33,7 @@ regression:
                 - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
                 - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
-                tags: "~@broken && @IbexaCommerce"
+                tags: "~@broken&&@IbexaCommerce"
             contexts: 
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext

--- a/behat_ibexa_content.yaml
+++ b/behat_ibexa_content.yaml
@@ -27,7 +27,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
-                tags: "~@broken && @IbexaContent"
+                tags: "~@broken&&@IbexaContent"
             contexts: 
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -35,7 +35,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
               - '%paths.base%/vendor/ezsystems/ezplatform-workflow/features/browser'
             filters:
-                tags: "~@broken && @IbexaExperience"
+                tags: "~@broken&&@IbexaExperience"
             contexts: 
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -89,7 +89,7 @@ regression:
               - '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/features/standard'
               - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
             filters:
-                tags: "~@broken && @IbexaOSS"
+                tags: "~@broken&&@IbexaOSS"
             contexts: 
                 - Behat\MinkExtension\Context\MinkContext
                 - EzSystems\Behat\API\Context\ContentContext


### PR DESCRIPTION
Removing these whitespaces gets rid of this error:
```
Deprecated: Tags with whitespace are deprecated and may be removed in a future version in /Users/mareknocon/Desktop/Sites/v3_2/vendor/behat/gherkin/src/Behat/Gherkin/Filter/TagFilter.php on line 38
```

Also, somehow, it gets rid of this error when running the test locally:
```
    1.0005   62771536  18. trigger_error() /Users/mareknocon/Desktop/Sites/v3_2/vendor/behat/gherkin/src/Behat/Gherkin/Filter/TagFilter.php:38
In NativeFileSessionHandler.php line 52:
  Warning: ini_set(): Headers already sent. You cannot change the session module's ini settings at this time
```

Behat doc reference: https://docs.behat.org/en/v2.5/guides/6.cli.html#gherkin-filters

Tested locally and in https://app.travis-ci.com/github/ezsystems/ezplatform-page-builder/builds/242777124

