### PR TITLE
Added workaround for taxonomy

### DIFF
--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -44,8 +44,8 @@ Feature: Editor that has access only to a Subtree of Content Structure
       | content     | reverserelatedlist |
     And I create a role "ReadNodesForSubtreeEditors"
     And I add policy "content" "read" to "ReadNodesForSubtreeEditors" with limitations
-      | limitationType      | limitationValue         |
-      | Location            | root,/FolderGrandParent |
+      | limitationType      | limitationValue                       |
+      | Location            | root,/FolderGrandParent,taxonomy/tags |
     And I add policy "content" "versionread" to "ReadNodesForSubtreeEditors" with limitations
       | limitationType      | limitationValue         |
       | Location            | root,/FolderGrandParent |

--- a/src/lib/API/Context/LimitationParser/LocationLimitationParser.php
+++ b/src/lib/API/Context/LimitationParser/LocationLimitationParser.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\Behat\API\Context\LimitationParser;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -38,8 +39,13 @@ class LocationLimitationParser implements LimitationParserInterface
 
         foreach (explode(',', $limitationValues) as $limitationValue) {
             $parsedUrl = $this->argumentParser->parseUrl($limitationValue);
-            $urlAlias = $this->urlAliasService->lookup($parsedUrl);
-            $location = $this->locationService->loadLocation($urlAlias->destination);
+            try {
+                $urlAlias = $this->urlAliasService->lookup($parsedUrl);
+                $location = $this->locationService->loadLocation($urlAlias->destination);
+            } catch (NotFoundException $exception) {
+                continue;
+            }
+
             $values[] = $location->id;
         }
 


### PR DESCRIPTION
Adding workaround for failing personas tests because of lack of permissions to read the Taxonomy Content Item.

When the issue is fixed this commit will have to be reverted.

Tested in:
https://github.com/ibexa/oss/pull/28
https://github.com/ibexa/content/pull/23