### PR TITLE
[CI] Removed ignore-platform-req from PHP 8 installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,9 @@ jobs:
         php:
           - '7.3'
           - '7.4'
+          - '8.0'
+          - '8.1'
         composer_options: [ "" ]
-        include:
-          - php: '8.0'
-            composer_options: "--ignore-platform-req php"
-          - php: '8.1'
-            composer_options: "--ignore-platform-req php"
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "ibexa/ci-scripts": "^0.1@dev",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezplatform-code-style": "^1.0.0",
+        "ezsystems/ezplatform-http-cache": "^2.3@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezplatform-code-style": "^1.0.0",
         "ezsystems/ezplatform-http-cache": "^2.3@dev",
+        "ezsystems/ezplatform-rest": "^1.3@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "friends-of-behat/mink-browserkit-driver": "^1.4",
         "friends-of-behat/mink-extension": "^2.4",
         "friends-of-behat/symfony-extension": "^2.1",
-        "fzaninotto/faker": "^1.9",
+        "fakerphp/faker": "^1.17",
         "guzzlehttp/psr7": "^1.6.1",
         "liuggio/fastest": "^1.7",
         "php-http/client-common": "^2.1",


### PR DESCRIPTION
Things done:
1) Removed ignoring PHP requirements on CI
2) Bumped Faker to a version supporting PHP 8 (`fzaninotto/Faker` is no longer developed: https://github.com/fzaninotto/Faker, `FakerPHP/Faker` is the new organisation - https://github.com/FakerPHP/Faker)
3) Added required packages to require-dev - they are unstable dependencies of dependencies and need to be added directly (because there are no stable releases supporting PHP 8 yet)