### PR TITLE
Fixed taxonomy location path

### DIFF
--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -44,8 +44,8 @@ Feature: Editor that has access only to a Subtree of Content Structure
       | content     | reverserelatedlist |
     And I create a role "ReadNodesForSubtreeEditors"
     And I add policy "content" "read" to "ReadNodesForSubtreeEditors" with limitations
-      | limitationType      | limitationValue                                          |
-      | Location            | root,/FolderGrandParent,taxonomy/tags,taxonomy/tags/root |
+      | limitationType      | limitationValue                             |
+      | Location            | root,/FolderGrandParent,/taxonomy/tags/root |
     And I add policy "content" "versionread" to "ReadNodesForSubtreeEditors" with limitations
       | limitationType      | limitationValue         |
       | Location            | root,/FolderGrandParent |

--- a/features/personas/subtree_editor.feature
+++ b/features/personas/subtree_editor.feature
@@ -44,8 +44,8 @@ Feature: Editor that has access only to a Subtree of Content Structure
       | content     | reverserelatedlist |
     And I create a role "ReadNodesForSubtreeEditors"
     And I add policy "content" "read" to "ReadNodesForSubtreeEditors" with limitations
-      | limitationType      | limitationValue                       |
-      | Location            | root,/FolderGrandParent,taxonomy/tags |
+      | limitationType      | limitationValue                                          |
+      | Location            | root,/FolderGrandParent,taxonomy/tags,taxonomy/tags/root |
     And I add policy "content" "versionread" to "ReadNodesForSubtreeEditors" with limitations
       | limitationType      | limitationValue         |
       | Location            | root,/FolderGrandParent |

--- a/src/lib/Core/Behat/ArgumentParser.php
+++ b/src/lib/Core/Behat/ArgumentParser.php
@@ -41,7 +41,7 @@ class ArgumentParser
             $url = substr($url, 1, strlen($url) - 1);
         }
 
-        if (strpos($url, 'root') === 0 ) {
+        if (strpos($url, 'root') === 0) {
             $url = str_replace('root', '', $url);
         }
 

--- a/src/lib/Core/Behat/ArgumentParser.php
+++ b/src/lib/Core/Behat/ArgumentParser.php
@@ -35,9 +35,17 @@ class ArgumentParser
      */
     public function parseUrl(string $url)
     {
-        $url = str_replace([' ', '@', ',', ':', $this->parameterProvider->getParameter('root_content_name'), 'root'], ['-', '-', '', '-', '', ''], $url);
+        $url = str_replace([' ', '@', ',', ':', $this->parameterProvider->getParameter('root_content_name')], ['-', '-', '', '-', ''], $url);
 
-        return 0 === strpos($url, '/') ? $url : sprintf('/%s', $url);
+        if (strpos($url, '/') === 0) {
+            $url = substr($url, 1, strlen($url) - 1);
+        }
+
+        if (strpos($url, 'root') === 0 ) {
+            $url = str_replace('root', '', $url);
+        }
+
+        return strpos($url, '/') === 0 ? $url : sprintf('/%s', $url);
     }
 
     public function parseLimitations(TableNode $limitations)

--- a/tests/Core/Behat/ArgumentParserTest.php
+++ b/tests/Core/Behat/ArgumentParserTest.php
@@ -40,6 +40,10 @@ class ArgumentParserTest extends TestCase
         return [
             ['', '/'],
             ['root', '/'],
+            ['/root', '/'],
+            ['/root/taxonomy', '/taxonomy'],
+            ['root/taxonomy', '/taxonomy'],
+            ['/taxonomy/tags/root', '/taxonomy/tags/root'],
             ['/', '/'],
             ['/Home', '/Home'],
             ['Home', '/Home'],


### PR DESCRIPTION
The location of the Taxonomy menu item has changed - it was `taxonomy/tags`, but now it's `/taxonomy/tags/root`

It's not enough to change it in the Scenario, because the `parseUrl` method replaced every `root` keyword occurance with an empty space - it's used to take into account that the name of the root Content Item can be different accross different product editions. Example usage:
https://github.com/ibexa/admin-ui/blob/f44128683057ddb8a09c572423113d999c988592/features/personas/SubtreeEditor.feature#L23-L24

It's all great, but because of that `/taxonomy/tags/root` becomes `taxonomy/tags` and we're back to square one 🙃 

I've changed ArgumentParser to change the root keyword only when it's in the beggining of the string - when it's later in the path it's left unchanged.

Added tests to make sure that it's working correctly.