### PR TITLE
Adapted ezbehat runner to Composer 2.2

### DIFF
--- a/bin/ezbehat
+++ b/bin/ezbehat
@@ -45,11 +45,11 @@ error(){
 }
 
 behat(){
-    ${BASH_SOURCE%/*}/behat ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}
+    "$COMPOSER_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}
 }
 
 fastest(){
-    get_behat_features | ${BASH_SOURCE%/*}/fastest -o -v "${BASH_SOURCE%/*}/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}"
+    get_behat_features | "$COMPOSER_BIN_DIR/fastest" -o -v "$COMPOSER_BIN_DIR/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}"
 }
 
 # Fastest option 'list-features' gives us the list of all features from given context in random order, which are later
@@ -57,7 +57,7 @@ fastest(){
 # times each build, often non optimal. To make this optimal we sort features by the number of scenarios in them
 # (descending) and run them in that order, to minimize final time gap between the threads.
 get_behat_features(){
-     ${BASH_SOURCE%/*}/behat ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
+     "$COMPOSER_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
 }
 
 for i in "$@"


### PR DESCRIPTION
Composer 2.2.2 changes the working directory when binaries are executed:
https://github.com/composer/composer/issues/10389
https://github.com/composer/composer/pull/10402

It's also mentioned in the release notes for Composer 2.2.2:
https://github.com/composer/composer/releases/tag/2.2.2
```
Added COMPOSER_BIN_DIR env var and _composer_bin_dir global containing the path to the bin-dir for binaries. Packages relying on finding the bin dir with $BASH_SOURCES[0] will need to update their binaries (#10402)
```

This PR updates our ezbehat runner so that it relies on `COMPOSER_BIN_DIR`, not `BASH_SOURCES` env variable.

