### PR TITLE
Fixed translating Content by setting initialLanguageCode

### DIFF
--- a/src/lib/API/Facade/ContentFacade.php
+++ b/src/lib/API/Facade/ContentFacade.php
@@ -101,6 +101,7 @@ class ContentFacade
         $location = $this->locationService->loadLocation($urlAlias->destination);
         $contentDraft = $this->contentService->createContentDraft($location->getContentInfo());
         $contentUpdateStruct = $this->contentService->newContentUpdateStruct();
+        $contentUpdateStruct->initialLanguageCode = $language;
 
         $this->contentDataProvider->setContentTypeIdentifier($contentDraft->getContentType()->identifier);
         $this->contentDataProvider->getFilledContentDataStruct($contentUpdateStruct, $contentItemData, $language);


### PR DESCRIPTION
https://doc.ibexa.co/en/latest/api/public_php_api_creating_content/#translating-content

```
To translate a Content item to a new language, you need to update it and provide a new initialLanguageCode:
```

Using this code for translations was semi-broken before this change, because the new `initialLanguageCode` was not set and the system did not register it fully as a new translation.