### PR TITLE
Added LanguageContext to Experience & Commerce

### DIFF
--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -15,6 +15,7 @@ regression:
             contexts:
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\LanguageContext
                 - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\UserContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -19,6 +19,7 @@ regression:
             contexts:
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\LanguageContext
                 - EzSystems\Behat\API\Context\RoleContext
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\UserContext


### PR DESCRIPTION
This PR fixes lack of LanguageContext for Experience & Commerce editions. Example error - https://github.com/ibexa/experience/runs/4928762776?check_suite_focus=true

>  --- Use --snippets-for CLI option to generate snippets for following setup-experience suite steps:
> 
>     Given Language "German" with code "ger-DE" exists
>     And Language "French" with code "fre-FR" exists