### PR TITLE
Adjust login provider

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -15,7 +15,7 @@ jobs:
             project-edition: 'oss'
             project-version: '^4.0.x-dev'
             test-suite:  '--profile=browser --suite=admin-ui-full'
-            test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'
+            test-setup-phase-1: '--profile=regression --suite=setup-oss --mode=standard'
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     examples:

--- a/features/setup/loginMethods/email_provider.feature
+++ b/features/setup/loginMethods/email_provider.feature
@@ -1,7 +1,8 @@
 Feature: Email provider setup for testing
 
+    @test
   Scenario: Set up both username and email providers
-    Given I set configuration to "security.providers.ezplatform" in "config/packages/security.yaml"
+    Given I set configuration to "security.providers.ibexa" in "config/packages/security.yaml"
     """
         chain:
             providers: [ ibexa_email, ibexa_username ]
@@ -9,11 +10,11 @@ Feature: Email provider setup for testing
     And I append configuration to "security.providers" in "config/packages/security.yaml"
     """
         ibexa_email:
-            id: ezpublish.security.user_provider.email
+            id: Ibexa\Core\MVC\Symfony\Security\User\EmailProvider
         ibexa_username:
-            id: ezpublish.security.user_provider.username
+            id: Ibexa\Core\MVC\Symfony\Security\User\UsernameProvider
     """
-    And I append configuration to "security.firewalls.ezpublish_front" in "config/packages/security.yaml"
+    And I append configuration to "security.firewalls.ibexa_front" in "config/packages/security.yaml"
     """
-        provider: ezplatform
+        provider: ibexa
     """


### PR DESCRIPTION
Adjusting tests to avoid the:
```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In SecurityExtension.php line 713:
!!                                                                                 
!!    Not configuring explicitly the provider for the "guard" listener on "ibexa_  
!!    front" firewall is ambiguous as there is more than one registered provider.  
!!                                                                                 
!!  
```
```
 In SecurityExtension.php line 713:
                                                                                                                                                               
  Not configuring explicitly the provider for the "form_login" listener on "ibexa_front" firewall is ambiguous as there is more than one registered provider.  
```
errors on CI

Ive also changed the CI setup here to run the full OSS setup during build (for better verification)