### PR TITLE
Adjusted parameter name to rebranding

### DIFF
--- a/src/bundle/DependencyInjection/eZBehatExtension.php
+++ b/src/bundle/DependencyInjection/eZBehatExtension.php
@@ -32,7 +32,7 @@ class eZBehatExtension extends Extension implements PrependExtensionInterface, C
             return;
         }
 
-        $container->setParameter('ezsettings.admin_group.notifications.success.timeout', 20000);
+        $container->setParameter('ibexa.site_access.config.admin_group.notifications.success.timeout', 20000);
     }
 
     public function prepend(ContainerBuilder $container)


### PR DESCRIPTION
The `ezsettings` parameter namespace is not used in v4, it has been replaced. The new parameter name has been taken from https://github.com/ibexa/admin-ui/blob/main/src/bundle/Resources/config/ezplatform_default_settings.yaml#L48

I'm pretty sure that this value is not taken into account and that's the cause of issues like:
```
     And I start creating a new Landing Page "BannerBlock"                         # Ibexa\PageBuilder\Behat\Context\PageBuilderContext::startCreatingNewLandingPage()
      WebDriver\Exception\NoSuchElement: Element not found with xpath, (//html/descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' ibexa-alert__close-btn ')])[1]
      
      no such element: Unable to locate element: {"method":"xpath","selector":"(//html/descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' ibexa-alert__close-btn ')])[1]"}
        (Session info: chrome=94.0.4606.61)
        (Driver info: chromedriver=94.0.4606.61 (418b78f5838ed0b1c69bb4e51ea0252171854915-refs/branch-heads/4606@{#1204}),platform=Linux 5.11.0-1028-azure x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:156
      Stack trace:
      #0 vendor/instaclick/php-webdriver/lib/WebDriver/Container.php(78): WebDriver\Exception::factory()
      #1 vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php(1040): WebDriver\Container->element()
      #2 vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php(792): Behat\Mink\Driver\Selenium2Driver->findElement()
      #3 vendor/friends-of-behat/mink/src/Element/NodeElement.php(153): Behat\Mink\Driver\Selenium2Driver->click()
      #4 vendor/ezsystems/behatbundle/src/lib/Browser/Element/Element.php(72): Behat\Mink\Element\NodeElement->click()
      #5 vendor/ibexa/admin-ui/src/lib/Behat/Component/Notification.php(47): Ibexa\Behat\Browser\Element\Element->click()
      #6 vendor/ibexa/admin-ui/src/lib/Behat/Page/ContentUpdateItemPage.php(65): Ibexa\AdminUi\Behat\Component\Notification->closeAlert()
      #7 vendor/ibexa/page-builder/src/lib/Behat/Page/PageBuilderEditor.php(253): Ibexa\AdminUi\Behat\Page\ContentUpdateItemPage->verifyIsLoaded()
      #8 vendor/ibexa/page-builder/src/lib/Behat/Context/PageBuilderContext.php(92): Ibexa\PageBuilder\Behat\Page\PageBuilderEditor->setField()
```
```
       | CodeBlock             | Code              |
        WebDriver\Exception\StaleElementReference: stale element reference: element is not attached to the page document
          (Session info: chrome=94.0.4606.61)
          (Driver info: chromedriver=94.0.4606.61 (418b78f5838ed0b1c69bb4e51ea0252171854915-refs/branch-heads/4606@{#1204}),platform=Linux 5.11.0-1028-azure x86_64) in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:156
        Stack trace:
        #0 vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php(165): WebDriver\Exception::factory()
        #1 vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php(245): WebDriver\AbstractWebDriver->curl()
        #2 vendor/instaclick/php-webdriver/lib/WebDriver/Container.php(239): WebDriver\AbstractWebDriver->__call()
        #3 vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php(806): WebDriver\Container->__call()
        #4 vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php(792): Behat\Mink\Driver\Selenium2Driver->clickOnElement()
        #5 vendor/friends-of-behat/mink/src/Element/NodeElement.php(153): Behat\Mink\Driver\Selenium2Driver->click()
        #6 vendor/ezsystems/behatbundle/src/lib/Browser/Element/Element.php(72): Behat\Mink\Element\NodeElement->click()
        #7 vendor/ibexa/admin-ui/src/lib/Behat/Component/Notification.php(47): Ibexa\Behat\Browser\Element\Element->click()
        #8 vendor/ibexa/admin-ui/src/lib/Behat/Page/ContentUpdateItemPage.php(65): Ibexa\AdminUi\Behat\Component\Notification->closeAlert()
        #9 vendor/ibexa/page-builder/src/lib/Behat/Page/PageBuilderEditor.php(253): Ibexa\AdminUi\Behat\Page\ContentUpdateItemPage->verifyIsLoaded()
        #10 vendor/ibexa/page-builder/src/lib/Behat/Context/PageBuilderContext.php(92): Ibexa\PageBuilder\Behat\Page\PageBuilderEditor->setField()
```

which started occuring in tests recently. You can see that the tests want to interact with a notification, but it disappears too fast.