### PR TITLE
Adjusted ezbehat to Composer 2.2.6 BC break

### DIFF
--- a/bin/ezbehat
+++ b/bin/ezbehat
@@ -45,11 +45,11 @@ error(){
 }
 
 behat(){
-    "$COMPOSER_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}
+    "$COMPOSER_RUNTIME_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}
 }
 
 fastest(){
-    get_behat_features | "$COMPOSER_BIN_DIR/fastest" -o -v "$COMPOSER_BIN_DIR/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}"
+    get_behat_features | "$COMPOSER_RUNTIME_BIN_DIR/fastest" -o -v "$COMPOSER_RUNTIME_BIN_DIR/behat {} ${CONFIG} ${PROFILE}${SUITE}${TAGS}--no-interaction -vv ${STRICT} ${OTHER_OPTIONS}"
 }
 
 # Fastest option 'list-features' gives us the list of all features from given context in random order, which are later
@@ -57,7 +57,7 @@ fastest(){
 # times each build, often non optimal. To make this optimal we sort features by the number of scenarios in them
 # (descending) and run them in that order, to minimize final time gap between the threads.
 get_behat_features(){
-     "$COMPOSER_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
+     "$COMPOSER_RUNTIME_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
 }
 
 for i in "$@"


### PR DESCRIPTION
Failing build:
https://github.com/ibexa/oss/runs/5286165981?check_suite_focus=true
```
Run cd ${HOME}/build/project
/var/www/vendor/ezsystems/behatbundle/bin/ezbehat: line 48: /behat: No such file or directory
Error: Process completed with exit code 127.
```

We've merged https://github.com/ezsystems/docker-php/pull/65 , which triggered a build of new images - they now contain the latest Composer version.

This version contains a BC Break: https://github.com/composer/composer/releases/tag/2.2.6
to which we need to adapt our runner script