### PR TITLE
IBX-2802: Allow to split Features into multiple groups

### DIFF
--- a/bin/ibexabehat
+++ b/bin/ibexabehat
@@ -82,7 +82,7 @@ case $i in
     -t=*|--tags=*)     TAGS="--tags=${i#*=} ";;
     -c=*|--config=*)   CONFIG="--config=${i#*=}";;
     --non-strict)      STRICT='';;
-    --group-count=*)     GROUP_COUNT=${i#*=};;
+    --group-count=*)   GROUP_COUNT=${i#*=};;
     --group-offset=*)  GROUP_OFFSET=${i#*=};;
     -h|--help)         usage; exit 1;;
     *)                 OTHER_OPTIONS="${OTHER_OPTIONS} ${i}";;

--- a/bin/ibexabehat
+++ b/bin/ibexabehat
@@ -10,8 +10,12 @@
 #   bin/ibexabehat --profile=adminui --suite=adminui
 #
 # for getting features list for given profiles/suites:
+# use --group-count and --group-offset to split the tests into multiple groups
 #   bin/ibexabehat --mode=get-features --profile=repository-forms --tags=~@broken
 #   bin/ibexabehat -m=get-features -p=regression -s=demoRegression
+#   bin/ibexabehat --mode=get-features --profile=repository-forms --tags=~@broken --group-count=2 --group-offset=0
+#   bin/ibexabehat --mode=get-features --profile=repository-forms --tags=~@broken --group-count=2 --group-offset=1
+
 
 PROFILE=''
 SUITE=''
@@ -20,6 +24,8 @@ CONFIG=''
 OTHER_OPTIONS=''
 MODE='parallel'
 STRICT='--strict'
+GROUP_COUNT=1
+GROUP_OFFSET=0
 
  # Help command output
 usage(){
@@ -34,6 +40,8 @@ Options:
 \t -s, --suite=SUITE; Behat tests suite;
 \t -t, --tags=TAGS; Behat tags filter;
 \t --non-strict; Run Behat in non-strict mode;
+\t --group-count; Split the tests into multiple groups
+\t --group-offset; Use together with --group-count, get Scenarios for a group
 " | column -t -s ";"
 }
 
@@ -57,7 +65,12 @@ fastest(){
 # times each build, often non optimal. To make this optimal we sort features by the number of scenarios in them
 # (descending) and run them in that order, to minimize final time gap between the threads.
 get_behat_features(){
-     "$COMPOSER_RUNTIME_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | uniq -c | sort --reverse | awk '{ print $2 }'
+     "$COMPOSER_RUNTIME_BIN_DIR/behat" ${CONFIG} ${PROFILE}${SUITE}${TAGS} --list-scenarios | \
+     awk '{ gsub(/:[0-9]+/,"",$1); print $1 }' | \
+     uniq -c | \
+     sort --reverse | \
+     awk '{ print $2 }' | \
+     awk -v GROUP_COUNT=$GROUP_COUNT -v GROUP_OFFSET=$GROUP_OFFSET 'NR % GROUP_COUNT == GROUP_OFFSET'
 }
 
 for i in "$@"
@@ -69,6 +82,8 @@ case $i in
     -t=*|--tags=*)     TAGS="--tags=${i#*=} ";;
     -c=*|--config=*)   CONFIG="--config=${i#*=}";;
     --non-strict)      STRICT='';;
+    --group-count=*)     GROUP_COUNT=${i#*=};;
+    --group-offset=*)  GROUP_OFFSET=${i#*=};;
     -h|--help)         usage; exit 1;;
     *)                 OTHER_OPTIONS="${OTHER_OPTIONS} ${i}";;
 esac

--- a/bin/ibexareport
+++ b/bin/ibexareport
@@ -36,6 +36,7 @@ error(){
 zip_report_files(){
 cd ${ALLURE_BUILD_PATH}
 TIMESTAMP=$(date "+h%H-m%M")
+SUFFIX=$(echo $RANDOM)
 if [ -z $REPOSITORY_NAME ];
 then
     REPORT_NAME="$(echo $GITHUB_REPOSITORY | cut -d'/' -f 2).$GITHUB_RUN_ID.$GITHUB_RUN_NUMBER";
@@ -43,7 +44,7 @@ else
     DATESTAMP=$(date "+%Y-%m-%d")
     REPORT_NAME="$REPOSITORY_NAME.manual.$DATESTAMP";
 fi
-ZIP_FILENAME="$REPORT_NAME-$TIMESTAMP"
+ZIP_FILENAME="$REPORT_NAME-$TIMESTAMP-$SUFFIX"
 ZIP_FILENAME_EX="$ZIP_FILENAME.zip"
 sudo zip $ZIP_FILENAME_EX *
 cd -


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2802

Used in https://github.com/ibexa/gh-workflows/pull/13

Example usages:

### Single job
```
~/De/r/sp/projekt on master !4 ?4 ❯ vendor/bin/ibexabehat --mode=get-features --profile=browser --suite=admin-ui --dry-run --group-count=1 --group-offset=0
ContentTypeFields.feature
Roles.feature
ObjectStates.feature
Sections.feature
Languages.feature
Bookmarks.feature
SystemInfo.feature
ContentTypeGroup.feature
ContentManagement.feature
ContentDraft.feature
Trash.feature
ContentType.feature
Authentication.feature
UserCreation.feature
SearchContent.feature
ContentPreview.feature
```

### Two jobs

```
~/Desktop/repos/speed-up-regression/projekt on master !4 ?4 ❯ vendor/bin/ibexabehat --mode=get-features --profile=browser --suite=admin-ui --dry-run --group-count=2 --group-offset=0            14.17.0 at 10:34:24
Roles.feature
Sections.feature
Bookmarks.feature
ContentTypeGroup.feature
ContentDraft.feature
ContentType.feature
UserCreation.feature
ContentPreview.feature
```
and
```
~/Desktop/repos/speed-up-regression/projekt on master !4 ?4 ❯ vendor/bin/ibexabehat --mode=get-features --profile=browser --suite=admin-ui --dry-run --group-count=2 --group-offset=1      14.17.0 at 10:36:18
ContentTypeFields.feature
ObjectStates.feature
Languages.feature
SystemInfo.feature
ContentManagement.feature
Trash.feature
Authentication.feature
SearchContent.feature
```

I had to change the way Allure report name are generated, because with the current naming schema (Hour/Minute timestamp) it was possible to have two runs share the same report name (see https://github.com/ibexa/commerce/actions/runs/2258069556 for jobs that share the same reports URL).
