### PR TITLE
Added cache warmer creating cache directory for JsRoutingBundle

### DIFF
--- a/features/examples/configuration.feature
+++ b/features/examples/configuration.feature
@@ -13,7 +13,7 @@ Feature: Example scenarios showing how to set configuration
   Scenario: Configure Varnish as http cache
     Given I set configuration to "ezplatform.http_cache"
     """
-        purge_type: 'http'
+        purge_type: 'varnish'
     """
     And  I append configuration to "default" siteaccess under "http_cache" key
     """

--- a/src/bundle/Cache/JsRoutingDirectoryCacheDirectoryCreator.php
+++ b/src/bundle/Cache/JsRoutingDirectoryCacheDirectoryCreator.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\BehatBundle\Cache;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class JsRoutingDirectoryCacheDirectoryCreator implements CacheWarmerInterface
+{
+    private const FOS_JS_ROUTING_CACHE_DIR = 'fosJsRouting';
+
+    public function isOptional()
+    {
+        return true;
+    }
+
+    public function warmUp(string $cacheDir)
+    {
+        // Workaround for https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/pull/434
+        $cachePath = $cacheDir . \DIRECTORY_SEPARATOR . self::FOS_JS_ROUTING_CACHE_DIR;
+        if (!file_exists($cachePath) && !mkdir($cachePath) && !is_dir($cachePath)) {
+            throw new \RuntimeException('Unable to create JsRoutingBundle cache directory ' . $cachePath);
+        }
+    }
+}

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -12,6 +12,8 @@ services:
         autoconfigure: true
         public: false
 
+    EzSystems\BehatBundle\Cache\JsRoutingDirectoryCacheDirectoryCreator: ~
+
     EzSystems\Behat\API\ContentData\ContentDataProvider:
          arguments:
             - '@ezpublish.api.service.content_type'


### PR DESCRIPTION
Replaces https://github.com/ibexa/ci-scripts/pull/45

This class will create the FosJsRouting cache directory every time the `cache:clear` command is run.

https://github.com/ibexa/ci-scripts/pull/46 needs to be merged first.

I had to adapt the example related to http-cache - `http` purge_type is no longer valid, this test has been passing only by mistake.