### PR TITLE
Added missing Context required for Bookmarks tests

### DIFF
--- a/behat_ibexa_commerce.yaml
+++ b/behat_ibexa_commerce.yaml
@@ -52,6 +52,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
                 - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext

--- a/behat_ibexa_content.yaml
+++ b/behat_ibexa_content.yaml
@@ -45,6 +45,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
                 - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext

--- a/behat_ibexa_experience.yaml
+++ b/behat_ibexa_experience.yaml
@@ -54,6 +54,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
                 - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -106,6 +106,7 @@ regression:
                 - Ibexa\AdminUi\Behat\BrowserContext\ContentViewContext
                 - Ibexa\AdminUi\Behat\BrowserContext\DashboardContext
                 - Ibexa\AdminUi\Behat\BrowserContext\LanguageContext
+                - Ibexa\AdminUi\Behat\BrowserContext\LeftMenuContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NavigationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\NotificationContext
                 - Ibexa\AdminUi\Behat\BrowserContext\ObjectStatesContext


### PR DESCRIPTION
Example failure: https://github.com/ibexa/oss/runs/5998086598?check_suite_focus=true
```

--- Failed scenarios:

    vendor/ezsystems/ezplatform-admin-ui/features/standard/Bookmarks.feature:27

7 scenarios (4 passed, 1 failed, 2 undefined)
38 steps (28 passed, 1 failed, 2 undefined, 7 skipped)
0m38.21s (46.23Mb)

--- Use --snippets-for CLI option to generate snippets for following oss suite steps:

    And I click on the left menu bar button "Browse"

```

Tested in https://github.com/ibexa/oss/pull/47