### PR TITLE
Added conflict with instaclick/php-webdriver:1.4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
             "Ibexa\\Behat\\": "src/lib/"
         }
     },
+    "conflict": {
+        "instaclick/php-webdriver": "1.4.12"
+    },
     "autoload-dev": {
         "psr-4": {
             "EzSystems\\Behat\\Test\\": "tests/"


### PR DESCRIPTION
Error:
```
Behat\Testwork\Call\Exception\FatalThrowableError: Type error: Return value of Ibexa\Behat\Browser\Element\Element::getAttribute() must be of the type string, array returned in vendor/ibexa/behat/src/lib/Browser/Element/Element.php:83
```

https://github.com/instaclick/php-webdriver/releases/tag/1.4.12

In current CI run:
```
  - Locking instaclick/php-webdriver (1.4.11)
```