### PR TITLE
Added containsElementsWithText assertion

### DIFF
--- a/src/lib/Browser/Assert/CollectionAssert.php
+++ b/src/lib/Browser/Assert/CollectionAssert.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Behat\Browser\Assert;
 
 use Ibexa\Behat\Browser\Element\ElementCollectionInterface;
+use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use PHPUnit\Framework\Assert;
 
@@ -80,6 +81,31 @@ class CollectionAssert implements CollectionAssertInterface
                 count($elements)
             )
         );
+
+        return $this->elementCollection;
+    }
+
+    public function containsElementsWithText(array $expectedElementTexts): ElementCollectionInterface
+    {
+        $elements = $this->elementCollection->toArray();
+        $this->elementCollection->setElements($elements);
+
+        $elementTexts = $this->elementCollection->mapBy(new ElementTextMapper());
+
+        foreach ($expectedElementTexts as $expectedElementText) {
+            Assert::assertContains(
+                $expectedElementText,
+                $elementTexts,
+                sprintf(
+                    "Failed asserting that Collection created with %s locator '%s': '%s' contains elements '%s'. Found '%s' instead.",
+                    $this->locator->getType(),
+                    $this->locator->getIdentifier(),
+                    $this->locator->getSelector(),
+                    implode(',', $expectedElementTexts),
+                    implode(',', $elementTexts),
+                )
+            );
+        }
 
         return $this->elementCollection;
     }

--- a/src/lib/Browser/Assert/CollectionAssertInterface.php
+++ b/src/lib/Browser/Assert/CollectionAssertInterface.php
@@ -17,4 +17,6 @@ interface CollectionAssertInterface
     public function hasElements(): ElementCollectionInterface;
 
     public function countEquals(int $expectedCount): ElementCollectionInterface;
+
+    public function containsElementsWithText(array $expectedElementTexts): ElementCollectionInterface;
 }

--- a/src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
+++ b/src/lib/Browser/Assert/Debug/Interactive/CollectionAssert.php
@@ -51,4 +51,13 @@ class CollectionAssert implements CollectionAssertInterface
             return $this->startInteractiveSessionOnException($exception, true);
         }
     }
+
+    public function containsElementsWithText(array $expectedElementTexts): ElementCollectionInterface
+    {
+        try {
+            return $this->baseCollectionAssert->containsElementsWithText($expectedElementTexts);
+        } catch (ExpectationFailedException $exception) {
+            return $this->startInteractiveSessionOnException($exception, true);
+        }
+    }
 }

--- a/tests/Browser/Element/Assert/CollectionAssertTest.php
+++ b/tests/Browser/Element/Assert/CollectionAssertTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Behat\Test\Browser\Element\Assert;
+
+use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
+use Ibexa\Behat\Browser\Assert\CollectionAssert;
+use Ibexa\Behat\Browser\Element\ElementCollection;
+use Ibexa\Behat\Browser\Locator\XPathLocator;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class CollectionAssertTest extends BaseTestCase
+{
+    /** @var \Ibexa\Behat\Browser\Locator\XPathLocator */
+    private $locator;
+
+    protected function setUp(): void
+    {
+        $this->locator = new XPathLocator('locator', '//');
+    }
+
+    /**
+     * @dataProvider provideForTestAssertionPasses
+     */
+    public function testAssertionPasses(array $expectedElementTexts, array $actualElementTexts): void
+    {
+        $collection = $this->createElementCollection($actualElementTexts);
+        $collectionAssert = new CollectionAssert($this->locator, $collection);
+        $returnedCollection = $collectionAssert->containsElementsWithText($expectedElementTexts);
+
+        $this->assertSame($collection, $returnedCollection);
+    }
+
+    /**
+     * @dataProvider provideForTestAssertionFails
+     */
+    public function testAssertionFails(array $expectedElementTexts, array $actualElementTexts): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $collectionAssert = new CollectionAssert($this->locator, $this->createElementCollection($actualElementTexts));
+        $collectionAssert->containsElementsWithText($expectedElementTexts);
+    }
+
+    public function provideForTestAssertionPasses(): iterable
+    {
+        return [
+            [[], []],
+            [[''], ['']],
+            [['Test1'], ['Test1']],
+            [['Test1', 'Test2'], ['Test1', 'Test2']],
+            [['Test1', 'Test2'], ['Test1', 'Test2', 'Test3']],
+            [['Test1', 'Test2'], ['Test3', 'Test2', 'Test1']],
+            [['Test1', 'Test2'], ['Test3', 'Test2', 'Test1']],
+        ];
+    }
+
+    public function provideForTestAssertionFails(): iterable
+    {
+        return [
+            [['Test1'], ['Test2']],
+            [['Test1', 'Test2'], ['Test1']],
+            [['Test1', 'Test2'], ['Test1', 'Test1']],
+        ];
+    }
+
+    private function createElementCollection(array $elementTexts): ElementCollection
+    {
+        return new ElementCollection($this->locator, array_map(function (string $elementText) {
+            return $this->createElement($elementText);
+        }, $elementTexts));
+    }
+}


### PR DESCRIPTION
Adds a new assertion for collections: `containsElementsWithText`

Usage:
```php
$this->getHTMLPage()
     ->findAll($myLocator)
     ->assert()->containsElementsWithText(['Publish','Save'];
```

Required by https://github.com/ezsystems/ezplatform-page-builder/pull/948