### PR TITLE
Removed custom env code in favour of Behat feature

### DIFF
--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -18,14 +18,14 @@ default:
     extensions:
         Behat\MinkExtension:
             files_path: '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/TestFiles/'
-            base_url: 'http://localhost'
+            base_url: '%env(string:WEB_HOST)%'
             goutte: ~
-            javascript_session: selenium
+            javascript_session: 'selenium'
             sessions:
                 selenium:
                     selenium2:
                         browser: chrome
-                        wd_host: 'http://localhost:4444/wd/hub'
+                        wd_host: '%env(string:SELENIUM_HOST)%'
                         capabilities:
                             extra_capabilities:
                                 chromeOptions:
@@ -37,7 +37,7 @@ default:
                                         - "--disable-features=site-per-process"
                 chrome:
                     chrome:
-                        api_url: "http://localhost:9222"
+                        api_url: '%env(string:CHROMIUM_HOST)%'
 
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
 
@@ -46,10 +46,7 @@ default:
 
         EzSystems\BehatBundle\BehatExtension:
             mink:
-                base_url: '%env(string:WEB_HOST)%'
                 default_javascript_session: '%env(string:MINK_DEFAULT_SESSION)%'
-                selenium_webdriver_host: '%env(string:SELENIUM_HOST)%'
-                chrome_api_url: '%env(string:CHROMIUM_HOST)%'
 
         Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "behat/behat": "^3.8",
+        "behat/behat": "^3.11",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",

--- a/features/examples/configuration.feature
+++ b/features/examples/configuration.feature
@@ -17,5 +17,5 @@ Feature: Example scenarios showing how to set configuration
     """
     And  I append configuration to "default" siteaccess under "http_cache" key
     """
-        purge_servers: ['http://my_purge_server']
+        purge_servers: ['http://web']
     """

--- a/src/bundle/BehatExtension.php
+++ b/src/bundle/BehatExtension.php
@@ -9,28 +9,18 @@ declare(strict_types=1);
 namespace EzSystems\BehatBundle;
 
 use Behat\Behat\EventDispatcher\ServiceContainer\EventDispatcherExtension;
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
-use DMore\ChromeDriver\ChromeDriver;
 use EzSystems\BehatBundle\Initializer\BehatSiteAccessInitializer;
 use FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 
 class BehatExtension implements Extension
 {
-    private const MINK_BASE_URL_PARAMETER = 'ibexa.platform.behat.mink.base_url';
-
     private const MINK_DEFAULT_JAVASCRIPT_SESSION_PARAMETER = 'ibexa.platform.behat.mink.default_javascript_session';
-
-    private const MINK_SELENIUM_WEBDRIVER_HOST = 'ibexa.platform.behat.mink.selenium.webdriver_host';
-
-    private const MINK_CHROME_API_URL = 'ibexa.platform.behat.mink.chrome.api_url';
 
     public function getConfigKey()
     {
@@ -39,24 +29,9 @@ class BehatExtension implements Extension
 
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasParameter(self::MINK_BASE_URL_PARAMETER)) {
-            $baseUrl = $container->getParameter(self::MINK_BASE_URL_PARAMETER);
-            $this->setBaseUrl($container, $baseUrl);
-        }
-
         if ($container->hasParameter(self::MINK_DEFAULT_JAVASCRIPT_SESSION_PARAMETER)) {
             $defaultJavascriptSession = $container->getParameter(self::MINK_DEFAULT_JAVASCRIPT_SESSION_PARAMETER);
             $this->setDefaultJavascriptSession($container, $defaultJavascriptSession);
-        }
-
-        if ($container->hasParameter(self::MINK_SELENIUM_WEBDRIVER_HOST)) {
-            $seleniumWebdriverHost = $container->getParameter(self::MINK_SELENIUM_WEBDRIVER_HOST);
-            $this->setSeleniumWebdriverHost($container, $seleniumWebdriverHost);
-        }
-
-        if ($container->hasParameter(self::MINK_CHROME_API_URL)) {
-            $chromeApiUrl = $container->getParameter(self::MINK_CHROME_API_URL);
-            $this->setChromeApiUrl($container, $chromeApiUrl);
         }
     }
 
@@ -70,10 +45,7 @@ class BehatExtension implements Extension
             ->children()
                 ->arrayNode('mink')
                     ->children()
-                        ->scalarNode('base_url')->defaultNull()->end()
                         ->scalarNode('default_javascript_session')->defaultNull()->end()
-                        ->scalarNode('selenium_webdriver_host')->defaultNull()->end()
-                        ->scalarNode('chrome_api_url')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end();
@@ -81,11 +53,6 @@ class BehatExtension implements Extension
 
     public function load(ContainerBuilder $container, array $config)
     {
-        $loader = new YamlFileLoader(
-            $container,
-            new FileLocator(__DIR__ . '/Resources/config')
-        );
-
         $this->loadSiteAccessInitializer($container);
         $this->setMinkParameters($container, $config);
     }
@@ -107,10 +74,7 @@ class BehatExtension implements Extension
         }
 
         $keyParameterMap = [
-            'base_url' => self::MINK_BASE_URL_PARAMETER,
             'default_javascript_session' => self::MINK_DEFAULT_JAVASCRIPT_SESSION_PARAMETER,
-            'selenium_webdriver_host' => self::MINK_SELENIUM_WEBDRIVER_HOST,
-            'chrome_api_url' => self::MINK_CHROME_API_URL,
         ];
 
         foreach ($keyParameterMap as $key => $parameter) {
@@ -121,53 +85,8 @@ class BehatExtension implements Extension
         }
     }
 
-    private function setBaseUrl(ContainerBuilder $container, string $baseUrl): void
-    {
-        $container->setParameter('mink.base_url', $baseUrl);
-        $parameters = $container->getParameter('mink.parameters');
-        $parameters['base_url'] = $baseUrl;
-        $container->setParameter('mink.parameters', $parameters);
-    }
-
     private function setDefaultJavascriptSession(ContainerBuilder $container, string $defaultJavascriptSession): void
     {
         $container->setParameter('mink.javascript_session', $defaultJavascriptSession);
-    }
-
-    private function setSeleniumWebdriverHost(ContainerBuilder $container, string $seleniumWebdriverHost): void
-    {
-        foreach ($this->getDriverDefinitions($container) as $driverDefinition) {
-            if (is_a($driverDefinition->getClass(), Selenium2Driver::class, true)) {
-                $driverDefinition->setArgument(2, $seleniumWebdriverHost);
-            }
-        }
-    }
-
-    private function setChromeApiUrl(ContainerBuilder $container, string $chromeApiUrl): void
-    {
-        foreach ($this->getDriverDefinitions($container) as $driverDefinition) {
-            if (is_a($driverDefinition->getClass(), ChromeDriver::class, true)) {
-                $driverDefinition->setArgument(0, $chromeApiUrl);
-            }
-        }
-    }
-
-    /**
-     * @return \Symfony\Component\DependencyInjection\Definition[]
-     */
-    private function getDriverDefinitions(ContainerBuilder $container): array
-    {
-        $minkDefinition = $container->getDefinition('mink');
-
-        $registerSessionCalls = array_filter($minkDefinition->getMethodCalls(), static function ($methodCall) {
-            return $methodCall[0] === 'registerSession';
-        });
-
-        return array_map(static function (array $registerSessionCall) {
-            /** @var \Symfony\Component\DependencyInjection\Definition $sessionDefinition */
-            $sessionDefinition = $registerSessionCall[1][1];
-
-            return $sessionDefinition->getArgument(0);
-        }, $registerSessionCalls);
     }
 }


### PR DESCRIPTION
Thanks to the the latest release of Behat (https://github.com/Behat/Behat/releases/tag/v3.11.0) we can remove some of the code introduced in https://github.com/ezsystems/BehatBundle/pull/168 .

That's because Behat now supports env placeholder variable resolution 🎉 

Sadly it's not possible to remove the default session env, the tests fail with:
```
 In MinkExtension.php line 250:
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]                                                              
  The javascript session must be one of the enabled javascript sessions (["selenium","chrome"]), but got %env(string:MINK_DEFAULT_SESSION)%  
Exception trace:
  at /var/www/vendor/friends-of-behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php:250
 Behat\MinkExtension\ServiceContainer\MinkExtension->loadSessions() at /var/www/vendor/friends-of-behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/MinkExtension.php:88
```

So the Behat PR solved only 3/4 of our problems, but it's a win anyway 😄 

One test was failing randomly, I've fixed it in https://github.com/ezsystems/BehatBundle/pull/277/commits/2540bd35d8b13d35cafc1987302e23bfccda4eeb - it's backport of a v4 commit (https://github.com/ibexa/behat/commit/a125dae282f6047e4754364868645812a99f02be)