### PR TITLE
Added Step creating a Content Item only if it doesn't exist

### DIFF
--- a/features/examples/content.feature
+++ b/features/examples/content.feature
@@ -3,14 +3,17 @@ Feature: Example scenarios showing how to use steps involving Languages, Content
   @admin
   Scenario Outline: Create a language, Content Type and Content Items
     Given Language "Polski" with code "pol-PL" exists
+    And a "folder" Content item named "Test Folder" exists in root
+      | name        | short_name  |
+      | Test Folder | Test Folder |
     And I create a "<contentTypeName>" Content Type in "Content" with "<contentTypeIdentifier>" identifier
       | Field Type  | Name         | Identifier        | Required | Searchable | Translatable | Settings        |
       | Text line   | Name         | name	           | yes      | yes	       | yes          |                 |
       | <fieldType> | TestedField  | testedfield       | yes      | no	       | yes          | <fieldSettings> |
-    And I create "Folder" Content items in root in "pol-PL"
+    And I create "Folder" Content items in "Test Folder" in "pol-PL"
       | name              | short_name          |
       | <contentTypeName> | <contentTypeName>   |
-    And I create 2 "<contentTypeIdentifier>" Content items in "<contentTypeName>" in "pol-PL"
+    And I create 2 "<contentTypeIdentifier>" Content items in "Test Folder/<contentTypeName>" in "pol-PL"
 
     Examples:
       | contentTypeName      | contentTypeIdentifier | fieldType                    | fieldSettings                                                         |

--- a/src/lib/API/Context/ContentContext.php
+++ b/src/lib/API/Context/ContentContext.php
@@ -42,6 +42,17 @@ class ContentContext implements Context
     }
 
     /**
+     * @Given a :contentTypeIdentifier Content item named :contentName exists in :parentUrl
+     */
+    public function contentItemExists(string $contentTypeIdentifier, string $contentName, string $parentUrl, TableNode $contentItemData): void
+    {
+        $parentUrl = $this->argumentParser->parseUrl($parentUrl);
+        $contentUrl = sprintf('%s/%s', $parentUrl, $this->argumentParser->parseUrl($contentName));
+        $contentData = $this->parseData($contentItemData)[0];
+        $this->contentFacade->createContentIfNotExists($contentTypeIdentifier, $contentUrl, $parentUrl, $contentData);
+    }
+
+    /**
      * @Given I create :contentTypeIdentifier Content items in :parentUrl in :language
      *
      * @param mixed $contentTypeIdentifier

--- a/src/lib/API/Facade/ContentFacade.php
+++ b/src/lib/API/Facade/ContentFacade.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\Behat\API\Facade;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\URLAliasService;
@@ -127,5 +128,25 @@ class ContentFacade
     private function flushHTTPcache(): void
     {
         $this->cacheManager->flush();
+    }
+
+    public function createContentIfNotExists(string $contentTypeIdentifier, string $contentUrl, string $parentUrl, array $contentItemData, string $language = 'eng-GB'): void
+    {
+        if ($this->contentExists($contentUrl)) {
+            return;
+        }
+
+        $this->createContent($contentTypeIdentifier, $parentUrl, $language, $contentItemData);
+    }
+
+    private function contentExists(string $contentUrl): bool
+    {
+        try {
+            $this->urlAliasService->lookup($contentUrl);
+
+            return true;
+        } catch (NotFoundException $exception) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3076

### Description
This PR adds a new Step that creates a Content Item only if it doesn't exist already.
This is great for creating containers for Content Items created in future Steps - as you can see in the picture only one TestFolder is created, even though the Step is invoked multiple times (for each Example in the Scenario outline)

![Zrzut ekranu 2022-09-27 o 13 36 25](https://user-images.githubusercontent.com/10993858/192515123-ff2356b4-7bf5-4722-bd6d-ab49e3158953.png)

### Reason

https://issues.ibexa.co/browse/IBX-3076 shows that UDW doesn't handle new Content Items (created in the background) when selecting items.

But if you perform the Step 8 differently - you create the new Content Item in "Media/Images", not "Media" - then Media can be browsed (UDW would still close after browsing to Media/Images).

By creating dedicated Folder containers for Scenarios we will stop the Scenarios from clashing with each other (because each Scenario will have its own container to create items) and the "main" containers - the Root location and Media - will keep working.

Added in:
https://github.com/ezsystems/ezplatform-admin-ui/pull/2070
https://github.com/ezsystems/ezplatform-page-builder/pull/967

And I believe these two PRs will be enough to solve this issue for now (based on analysis of past test failures)

