### PR TITLE
Added a way of declaring variables in interactive debug

### DIFF
--- a/src/lib/Core/Debug/InteractiveDebuggerTrait.php
+++ b/src/lib/Core/Debug/InteractiveDebuggerTrait.php
@@ -20,17 +20,20 @@ use RuntimeException;
 
 trait InteractiveDebuggerTrait
 {
-    public function setInteractiveBreakpoint(): void
+    /**
+     * @var array Key - name of the variable Value - value of the variable, example: ['myVariable' => 'testValue']
+     */
+    public function setInteractiveBreakpoint(array $variables = []): void
     {
-        $this->startInteractiveSession(null, false);
+        $this->startInteractiveSession(null, false, $variables);
     }
 
     public function startInteractiveSessionOnException(Exception $exception, bool $expectsReturnValue)
     {
-        return $this->startInteractiveSession($exception, $expectsReturnValue);
+        return $this->startInteractiveSession($exception, $expectsReturnValue, []);
     }
 
-    protected function startInteractiveSession(?Exception $exception, bool $isReturnValueExpected)
+    protected function startInteractiveSession(?Exception $exception, bool $isReturnValueExpected, array $variables)
     {
         if ($this->isRunningInteractive()) {
             if ($exception !== null) {
@@ -49,6 +52,7 @@ trait InteractiveDebuggerTrait
         $this->addCommands($sh, $component);
         $sh->writeStartupMessages();
         $sh->setBoundObject($component);
+        $sh->setScopeVariables($variables);
         $sh->addBaseImports();
         if ($exception !== null) {
             $sh->displayExceptionMessage($exception);


### PR DESCRIPTION
Imagine you have the following code:

```php
    public function addFieldDefinition(string $fieldName)
    {
        $this->setInteractiveBreakpoint();
        $this->getHTMLPage()->find($this->getLocator('fieldDefinitionSearch'))->setValue($fieldName);

        // rest of the code
    }
```

Every time you want to execute the current code in the interactive debugging mode you need to define the "$fieldName" variable - becuase it's not present and the code relies on it.

https://user-images.githubusercontent.com/10993858/192992184-a4916a17-2154-4ac3-bfc9-3422e65985d7.mp4

This PR allows you to start the interactive debugging like this:
```php
    public function addFieldDefinition(string $fieldName)
    {
        $this->setInteractiveBreakpoint(['fieldName' => $fieldName]);
        $this->getHTMLPage()->find($this->getLocator('fieldDefinitionSearch'))->setValue($fieldName);

        // rest of the code
    }
```

https://user-images.githubusercontent.com/10993858/192992536-6a2c6306-e7bb-4daf-8ab3-d438be54728e.mp4

The variable `fieldName` will be defined when the interactive session is started - making life a bit easier



