### PR TITLE
[Known issues] Expanded criteria for ContentTypeCreatedInTheBackground

### DIFF
--- a/src/lib/Core/Log/Failure/KnownIssues/ContentTypeCreatedInTheBackground.php
+++ b/src/lib/Core/Log/Failure/KnownIssues/ContentTypeCreatedInTheBackground.php
@@ -15,7 +15,8 @@ class ContentTypeCreatedInTheBackground implements KnownIssueInterface
     public function matches(TestFailureData $testFailureData): bool
     {
         return $testFailureData->applicationLogContainsFragment('DefaultChoiceListFactory') &&
-            $testFailureData->applicationLogContainsFragment('Notice: Undefined index');
+            ($testFailureData->applicationLogContainsFragment('Warning: Undefined array key') ||
+            $testFailureData->applicationLogContainsFragment('Notice: Undefined index'));
     }
 
     public function getJiraReference(): string


### PR DESCRIPTION
This PR expands the criteria for ContentTypeCreatedInTheBackground to match failures like this one:
https://github.com/ibexa/commerce/actions/runs/3170231456/jobs/5162679016

This code is already present for v4:
https://github.com/ibexa/behat/blob/main/src/lib/Core/Log/Failure/KnownIssues/ContentTypeCreatedInTheBackground.php#L18-L19

I didn't know that the there are two variants of this error on v3 as well.