### PR TITLE
[Composer] Allowed installing PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 .phpunit.result.cache
 .php_cs.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "guzzlehttp/psr7": "^1.6.1",
         "liuggio/fastest": "^1.7",
         "php-http/client-common": "^2.1",
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
         "symfony/config": "^5.0",
         "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,9 @@
-<phpunit
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        colors="true">
-    <testsuites>
-        <testsuite name="EzSystems\BehatBundle">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="EzSystems\BehatBundle">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Browser/Element/Assert/CollectionAssertTest.php
+++ b/tests/Browser/Element/Assert/CollectionAssertTest.php
@@ -46,7 +46,7 @@ class CollectionAssertTest extends BaseTestCase
         $collectionAssert->containsElementsWithText($expectedElementTexts);
     }
 
-    public function provideForTestAssertionPasses(): iterable
+    public static function provideForTestAssertionPasses(): iterable
     {
         return [
             [[], []],
@@ -59,7 +59,7 @@ class CollectionAssertTest extends BaseTestCase
         ];
     }
 
-    public function provideForTestAssertionFails(): iterable
+    public static function provideForTestAssertionFails(): iterable
     {
         return [
             [['Test1'], ['Test2']],

--- a/tests/Browser/Element/Criterion/ChildElementTextCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ChildElementTextCriterionTest.php
@@ -10,8 +10,8 @@ namespace EzSystems\Behat\Test\Browser\Element\Criterion;
 
 use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
 use Ibexa\Behat\Browser\Element\Criterion\ChildElementTextCriterion;
-use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use Ibexa\Behat\Browser\Locator\XPathLocator;
 use PHPUnit\Framework\Assert;
 
@@ -20,19 +20,20 @@ class ChildElementTextCriterionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestMatches
      */
-    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    public function testMatches(LocatorInterface $locator, string $childElementText, bool $shouldMatch): void
     {
         $criterion = new ChildElementTextCriterion(new XPathLocator('id', 'selector'), 'expectedChildText');
+        $element = $this->createElementWithChildElement('ignore', $locator, $this->createElement($childElementText));
 
         Assert::assertEquals($shouldMatch, $criterion->matches($element));
     }
 
-    public function dataProviderTestMatches(): array
+    public static function dataProviderTestMatches(): array
     {
         return [
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), $this->createElement('expectedChildText')), true],
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'selector'), $this->createElement('notExpectedChildText')), false],
-            [$this->createElementWithChildElement('ignore', new XPathLocator('id', 'invalidSelector'), $this->createElement('expectedChildText')), false],
+            [new XPathLocator('id', 'selector'), 'expectedChildText', true],
+            [new XPathLocator('id', 'selector'), 'notExpectedChildText', false],
+            [new XPathLocator('id', 'invalidSelector'), 'expectedChildText', false],
         ];
     }
 

--- a/tests/Browser/Element/Criterion/ElementAttributeCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ElementAttributeCriterionTest.php
@@ -19,19 +19,20 @@ class ElementAttributeCriterionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestMatches
      */
-    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    public function testMatches(string $attributeName, string $attributeValue, bool $shouldMatch): void
     {
         $criterion = new ElementAttributeCriterion('expectedAttribute', 'expectedValue');
+        $element = $this->createElementWithAttribute($attributeName, $attributeValue);
 
         Assert::assertEquals($shouldMatch, $criterion->matches($element));
     }
 
-    public function dataProviderTestMatches(): array
+    public static function dataProviderTestMatches(): array
     {
         return [
-            [$this->createElementWithAttribute('expectedAttribute', ''), false],
-            [$this->createElementWithAttribute('expectedAttribute', 'notexpectedValue'), false],
-            [$this->createElementWithAttribute('expectedAttribute', 'expectedValue'), true],
+            ['expectedAttribute', '', false],
+            ['expectedAttribute', 'notexpectedValue', false],
+            ['expectedAttribute', 'expectedValue', true],
         ];
     }
 

--- a/tests/Browser/Element/Criterion/ElementTextCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ElementTextCriterionTest.php
@@ -10,7 +10,6 @@ namespace EzSystems\Behat\Test\Browser\Element\Criterion;
 
 use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
-use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -19,18 +18,19 @@ class ElementTextCriterionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestMatches
      */
-    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    public function testMatches(string $elementText, bool $shouldMatch): void
     {
         $criterion = new ElementTextCriterion('expectedText');
+        $element = $this->createElement($elementText);
 
         Assert::assertEquals($shouldMatch, $criterion->matches($element));
     }
 
-    public function dataProviderTestMatches(): array
+    public static function dataProviderTestMatches(): array
     {
         return [
-            [$this->createElement('expectedText'), true],
-            [$this->createElement('notExpectedChildText'), false],
+            ['expectedText', true],
+            ['notExpectedChildText', false],
         ];
     }
 

--- a/tests/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
+++ b/tests/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php
@@ -10,7 +10,6 @@ namespace EzSystems\Behat\Test\Browser\Element\Criterion;
 
 use EzSystems\Behat\Test\Browser\Element\BaseTestCase;
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextFragmentCriterion;
-use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
 use PHPUnit\Framework\Assert;
 
@@ -19,19 +18,19 @@ class ElementTextFragmentCriterionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestMatches
      */
-    public function testMatches(ElementInterface $element, bool $shouldMatch): void
+    public function testMatches(string $elementText, bool $shouldMatch): void
     {
         $criterion = new ElementTextFragmentCriterion('text');
-
+        $element = $this->createElement($elementText);
         Assert::assertEquals($shouldMatch, $criterion->matches($element));
     }
 
-    public function dataProviderTestMatches(): array
+    public static function dataProviderTestMatches(): array
     {
         return [
-            [$this->createElement('text'), true],
-            [$this->createElement('thisIsALongertext'), true],
-            [$this->createElement('thisStringDoesNotContainText'), false],
+            ['text', true],
+            ['thisIsALongertext', true],
+            ['thisStringDoesNotContainText', false],
         ];
     }
 

--- a/tests/Browser/Element/ElementCollectionTest.php
+++ b/tests/Browser/Element/ElementCollectionTest.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 namespace EzSystems\Behat\Test\Browser\Element;
 
 use Ibexa\Behat\Browser\Element\Criterion\ElementTextCriterion;
-use Ibexa\Behat\Browser\Element\ElementCollection;
 use Ibexa\Behat\Browser\Element\ElementInterface;
 use Ibexa\Behat\Browser\Element\Mapper\ElementTextMapper;
 use Ibexa\Behat\Browser\Exception\ElementNotFoundException;
 use Ibexa\Behat\Browser\Locator\CSSLocator;
+use Ibexa\Behat\Browser\Locator\LocatorInterface;
 use PHPUnit\Framework\Assert;
 
 class ElementCollectionTest extends BaseTestCase
@@ -61,25 +61,23 @@ class ElementCollectionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestAny
      */
-    public function testAny(ElementCollection $collection, bool $expectedAnyValue): void
+    public function testAny(LocatorInterface $locator, array $elementNames, bool $expectedAnyValue): void
     {
+        $collection = $this->createCollection($locator, ...$elementNames);
         Assert::assertEquals($expectedAnyValue, $collection->any());
     }
 
-    public function dataProviderTestAny(): array
+    public static function dataProviderTestAny(): array
     {
         return [
             [
-                $this->createCollection(
                 new CSSLocator('identifier', 'selector'),
-                'Element1', 'Element2', 'Element3'
-                ),
+                ['Element1', 'Element2', 'Element3'],
                 true,
             ],
             [
-                $this->createCollection(
-                    new CSSLocator('identifier', 'selector'),
-                ),
+                new CSSLocator('identifier', 'selector'),
+                [],
                 false,
             ],
         ];
@@ -88,25 +86,23 @@ class ElementCollectionTest extends BaseTestCase
     /**
      * @dataProvider dataProviderTestEmpty
      */
-    public function testEmpty(ElementCollection $collection, bool $expectedEmptyValue): void
+    public function testEmpty(LocatorInterface $locator, array $elementNames, bool $expectedEmptyValue): void
     {
+        $collection = $this->createCollection($locator, ...$elementNames);
         Assert::assertEquals($expectedEmptyValue, $collection->empty());
     }
 
-    public function dataProviderTestEmpty(): array
+    public static function dataProviderTestEmpty(): array
     {
         return [
             [
-                $this->createCollection(
-                    new CSSLocator('identifier', 'selector'),
-                    'Element1', 'Element2', 'Element3'
-                ),
+                new CSSLocator('identifier', 'selector'),
+                ['Element1', 'Element2', 'Element3'],
                 false,
             ],
             [
-                $this->createCollection(
-                    new CSSLocator('identifier', 'selector'),
-                ),
+                new CSSLocator('identifier', 'selector'),
+                [],
                 true,
             ],
         ];

--- a/tests/Browser/Element/ElementTest.php
+++ b/tests/Browser/Element/ElementTest.php
@@ -147,7 +147,7 @@ class ElementTest extends BaseTestCase
         Assert::assertEquals($expectedElementText, $element->find($locator)->getText());
     }
 
-    public function dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFind(): array
+    public static function dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFind(): array
     {
         return [
             [new VisibleCSSLocator('id', 'selector'), 'VisibleElement'],
@@ -170,7 +170,7 @@ class ElementTest extends BaseTestCase
         Assert::assertCount($expectedElementCount, $element->findAll($locator));
     }
 
-    public function dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFindAll(): array
+    public static function dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFindAll(): array
     {
         return [
             [new VisibleCSSLocator('id', 'selector'), 1],

--- a/tests/Core/Behat/ArgumentParserTest.php
+++ b/tests/Core/Behat/ArgumentParserTest.php
@@ -35,7 +35,7 @@ class ArgumentParserTest extends TestCase
         Assert::assertEquals($expectedResult, $actualResult);
     }
 
-    public function provideUrlData()
+    public static function provideUrlData()
     {
         return [
             ['', '/'],


### PR DESCRIPTION
Issues resolved:
```
There was 1 PHPUnit warning:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

--

There were 11 PHPUnit deprecations:

1) EzSystems\Behat\Test\Browser\Element\Assert\CollectionAssertTest::testAssertionPasses
Data Provider method EzSystems\Behat\Test\Browser\Element\Assert\CollectionAssertTest::provideForTestAssertionPasses() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Assert/CollectionAssertTest.php:30

2) EzSystems\Behat\Test\Browser\Element\Assert\CollectionAssertTest::testAssertionFails
Data Provider method EzSystems\Behat\Test\Browser\Element\Assert\CollectionAssertTest::provideForTestAssertionFails() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Assert/CollectionAssertTest.php:42

3) EzSystems\Behat\Test\Browser\Element\Criterion\ChildElementTextCriterionTest::testMatches
Data Provider method EzSystems\Behat\Test\Browser\Element\Criterion\ChildElementTextCriterionTest::dataProviderTestMatches() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Criterion/ChildElementTextCriterionTest.php:23

4) EzSystems\Behat\Test\Browser\Element\Criterion\ElementAttributeCriterionTest::testMatches
Data Provider method EzSystems\Behat\Test\Browser\Element\Criterion\ElementAttributeCriterionTest::dataProviderTestMatches() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Criterion/ElementAttributeCriterionTest.php:22

5) EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextCriterionTest::testMatches
Data Provider method EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextCriterionTest::dataProviderTestMatches() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Criterion/ElementTextCriterionTest.php:22

6) EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextFragmentCriterionTest::testMatches
Data Provider method EzSystems\Behat\Test\Browser\Element\Criterion\ElementTextFragmentCriterionTest::dataProviderTestMatches() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/Criterion/ElementTextFragmentCriterionTest.php:22

7) EzSystems\Behat\Test\Browser\Element\ElementCollectionTest::testAny
Data Provider method EzSystems\Behat\Test\Browser\Element\ElementCollectionTest::dataProviderTestAny() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/ElementCollectionTest.php:64

8) EzSystems\Behat\Test\Browser\Element\ElementCollectionTest::testEmpty
Data Provider method EzSystems\Behat\Test\Browser\Element\ElementCollectionTest::dataProviderTestEmpty() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/ElementCollectionTest.php:91

9) EzSystems\Behat\Test\Browser\Element\ElementTest::testAdditionalLocatorConditionsAreAppliedWhenUsingFind
Data Provider method EzSystems\Behat\Test\Browser\Element\ElementTest::dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFind() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/ElementTest.php:137

10) EzSystems\Behat\Test\Browser\Element\ElementTest::testAdditionalLocatorConditionsAreAppliedWhenUsingFindAll
Data Provider method EzSystems\Behat\Test\Browser\Element\ElementTest::dataProvidertestAdditionalLocatorConditionsAreAppliedWhenUsingFindAll() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Browser/Element/ElementTest.php:161

11) EzSystems\Behat\Test\Core\Behat\ArgumentParserTest::testParserGivenUrlCorrectly
Data Provider method EzSystems\Behat\Test\Core\Behat\ArgumentParserTest::provideUrlData() is not static

/home/runner/work/BehatBundle/BehatBundle/tests/Core/Behat/ArgumentParserTest.php:26
```


1) I've migrated the config using the supplied option
2) All data providers are now static
3) `$this` calls inside static providers needed to be moved to the tests