### PR TITLE
Backported Chrome stability flags

### DIFF
--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -35,6 +35,9 @@ default:
                                         - "--no-sandbox"
                                         # problem with different iframe host  - https://bugs.chromium.org/p/chromedriver/issues/detail?id=2758
                                         - "--disable-features=site-per-process"
+                                        - "--disable-renderer-backgrounding"
+                                        - "--disable-background-timer-throttling"
+                                        - "--disable-backgrounding-occluded-windows"
                 chrome:
                     chrome:
                         api_url: '%env(string:CHROMIUM_HOST)%'


### PR DESCRIPTION
Backporting the Chrome stability flags from https://github.com/ibexa/behat/pull/59 - they are working on lower Chrome version as well and should make the tests more stable.