### PR TITLE
 Fixed error handling when InteractiveDebug is used outside Component class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "bin": ["bin/ibexabehat", "bin/ibexareport"],
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": false
         }
     }
 }

--- a/src/lib/Core/Debug/InteractiveDebuggerTrait.php
+++ b/src/lib/Core/Debug/InteractiveDebuggerTrait.php
@@ -83,9 +83,13 @@ trait InteractiveDebuggerTrait
     {
         $trace = debug_backtrace();
         foreach ($trace as $traceLine) {
-            if ($traceLine['function'] === 'eval') {
+            if (!array_key_exists('function', $traceLine) ||
+                    $traceLine['function'] === 'eval' ||
+                    !array_key_exists('object', $traceLine)
+            ) {
                 continue;
             }
+
             $object = $traceLine['object'];
             if ($object instanceof Component) {
                 return $object;


### PR DESCRIPTION
This PR fixes the following error:
```
 When I click edit "TestMyDraft"                                     
 # Ibexa\AdminUi\Behat\BrowserContext\MyDraftsContext::iClickEdit()
      Notice: Undefined index: object in vendor/ibexa/behat/src/lib/Core/Debug/InteractiveDebuggerTrait.php line 89
```

when InteractiveDebug mode is used outside of the Page/Component classes. 