### PR TITLE
[Composer] Set range from 3.11 to <3.17 for behat/behat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 10
 
     strategy:
@@ -47,7 +47,7 @@ jobs:
 
   cs_fix:
     name: Run code style check
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
         php:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "behat/behat": "^3.16",
+        "behat/behat": "^3.11 || ^3.16",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "behat/behat": "^3.11",
-        "behat/gherkin": "~4.10.0",
+        "behat/behat": "^3.16",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.11",
+        "behat/gherkin": "~4.12.0",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.11",
-        "behat/gherkin": "~4.12.0",
+        "behat/gherkin": "~4.10.0",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "behat/behat": "^3.11 || ^3.16",
+        "behat/behat": ">=3.11 <3.17",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",


### PR DESCRIPTION
**Update**: After the backport of the file paths fix (https://github.com/Behat/Behat/pull/1636) and release of https://github.com/Behat/Behat/releases/tag/v3.16.1 behat/gherkin version does not need to be pinned. Instead requirement for behat/behat is set to a range limited by <3.17.

Tested on v4.6 in https://github.com/ibexa/behat/pull/140.

~To unblock CI, lowering `behat/gherkin` dependency after release of https://github.com/Behat/Gherkin/releases/tag/v4.13.0, ref. https://github.com/Behat/Gherkin/issues/317.~

~Version is dictated by PHP 7.3 supported by Ibexa DXP v3.3.~