### PR TITLE
[Composer] Allow newer versions of behat/behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "behat/behat": ">=3.11 <3.17",
+        "behat/behat": "^3.11",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",


### PR DESCRIPTION
The upper 3.17.0 constraint was added to fix an incompatibility when installing behat/gherkin >= v4.13.0 (which can only be installed on PHP >= 8.1, older PHP versions are not affected).

The newer gherkin package can only be used with behat/behat v3.16.1 or >= v3.20.0.

However, this project was stuck on v3.16.1 because of dependency conflicts with behat/behat v3.17.0 and above.

These dependency conflicts (on nikic/php-parser and composer/xdebug-handler) have been resolved in behat/behat v3.23.0. It should now be safe to accept newer Behat minor / bugfix releases.

This change therefore reverts the constraint added in #298. With this requirement:

* On PHP <= 8.1, composer will install behat/gherkin @ v4.10.0 and behat/behat @v3.15.0. These versions are compatible and are the last that support PHP 8.1 and below.
* On PHP 8.1 and above, composer will install the latest behat/gherkin and behat/behat (currently v4.14.0 and v3.23.0 respectively). This combination of versions is also compatible.