### PR TITLE
Bumped psy/psysh from ^0.10.8 to ^0.11.23 due to security advisory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/process": "^5.4",
         "symfony/property-access": "^5.0",
         "symfony/yaml": "^5.0",
-        "psy/psysh": "^0.10.8"
+        "psy/psysh": "^0.11.23"
     },
     "require-dev": {
         "ibexa/ci-scripts": "^0.1@dev",


### PR DESCRIPTION
#### Related PRs:
- https://github.com/ibexa/website-skeleton/pull/19

#### Description:

Composer reported:
`ezsystems/behatbundle 8.3.x-dev requires psy/psysh ^0.10.8 -> found psy/psysh[v0.10.8, ..., v0.10.12] but these were not loaded, because they are affected by security advisories`
in e.g. https://github.com/ibexa/oss/actions/runs/22201685687/job/64215959991#step:10:240.

This PR bumps `psy/psysh` requirement from ^0.10.8 to ^0.11.23.

The unaffected versions at this moment are:
https://packagist.org/packages/psy/psysh#v0.11.23
https://packagist.org/packages/psy/psysh#v0.12.19
https://packagist.org/packages/psy/psysh#v0.12.20
Ref. https://packagist.org/packages/psy/psysh

CI is red because authentication fails in ezsystems org:
`Failed to download recipe: Could not authenticate against github.com`.
Ref. https://github.com/ezsystems/BehatBundle/actions/runs/22179961017/job/64138787726?pr=301#step:10:879

Regression builds - all passed:
https://github.com/ibexa/oss/pull/261
https://github.com/ibexa/content/pull/156
https://github.com/ibexa/experience/pull/578
https://github.com/ibexa/commerce/pull/1692