### PR TITLE
Add conflict for Mink BrowserKitDriver v1.6.3

### DIFF
--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -17,7 +17,7 @@ default:
         Behat\MinkExtension:
             files_path: '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/TestFiles/'
             base_url: '%env(string:WEB_HOST)%'
-            goutte: ~
+            browserkit_http: ~
             javascript_session: 'selenium'
             sessions:
                 selenium:

--- a/behat_ibexa_oss.yaml
+++ b/behat_ibexa_oss.yaml
@@ -17,7 +17,7 @@ default:
         Behat\MinkExtension:
             files_path: '%paths.base%/vendor/ezsystems/ezplatform-admin-ui/src/lib/Behat/TestFiles/'
             base_url: '%env(string:WEB_HOST)%'
-            browserkit_http: ~
+            goutte: ~
             javascript_session: 'selenium'
             sessions:
                 selenium:

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.11",
+        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "behat/behat": "^3.11",
-        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "bex/behat-screenshot": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",
@@ -56,7 +55,8 @@
         }
     },
     "conflict": {
-        "instaclick/php-webdriver": "1.4.12"
+        "instaclick/php-webdriver": "1.4.12",
+        "friends-of-behat/mink-browserkit-driver": "1.6.3"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
This pull request adds a conflict in composer.json to prevent the installation of `friends-of-behat/mink-browserkit-driver` version 1.6.3.

Regression: https://github.com/ibexa/experience/pull/588